### PR TITLE
removed topology and affinity removal from webhook

### DIFF
--- a/pkg/handlers/webhookAdmission.go
+++ b/pkg/handlers/webhookAdmission.go
@@ -206,22 +206,6 @@ func adjustResources(ctx context.Context, pod *corev1.Pod, clusterID string, cfg
 	containers = append(containers, pod.Spec.Containers...)
 	containers = append(containers, pod.Spec.InitContainers...)
 	var patches []map[string]any
-	if len(pod.Spec.TopologySpreadConstraints) > 0 {
-		logging.Infof(ctx, "Removing %d topologySpreadConstraints from pod %s/%s", len(pod.Spec.TopologySpreadConstraints), pod.Namespace, getPodName(pod))
-		patches = append(patches, map[string]any{
-			"op":   "remove",
-			"path": "/spec/topologySpreadConstraints",
-		})
-	}
-
-	if pod.Spec.Affinity != nil && pod.Spec.Affinity.PodAntiAffinity != nil {
-		logging.Infof(ctx, "Removing podAntiAffinity from pod %s/%s", pod.Namespace, getPodName(pod))
-		patches = append(patches, map[string]any{
-			"op":   "remove",
-			"path": "/spec/affinity/podAntiAffinity",
-		})
-	}
-
 	for i, container := range containers {
 		containerPath := fmt.Sprintf("/spec/containers/%d", i)
 		if i >= len(pod.Spec.Containers) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified webhook admission control logic by removing automatic patch generation for topologySpreadConstraints and podAntiAffinity configuration. This optimization reduces unnecessary modifications to pod resources during the admission phase while maintaining all other patch generation functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->