### PR TITLE
Added handling for daemonset pods to not increase resources

### DIFF
--- a/pkg/task/applystrategies/adjust_amongst_pods_distributed_strategy.go
+++ b/pkg/task/applystrategies/adjust_amongst_pods_distributed_strategy.go
@@ -201,13 +201,8 @@ func (s *AdjustAmongstPodsDistributedStrategy) OptimizeNode(kubeClient *kubernet
 				recommendedMemory, restMemory := s.getRecommendedAndRestMemory(containerStat)
 
 				if pod.WorkloadKind == utils.DaemonSetKind {
-					containerResource, err := pod.GetContainerResource(containerStat.ContainerName)
-					if err != nil {
-						logging.Errorf(context.Background(), "Error getting container resource for container %s: %v", containerStat.ContainerName, err)
-						continue
-					}
-					currentCPU := containerResource.CPURequest
-					currentMemory := containerResource.MemoryRequest
+					currentCPU := currentResource.CPURequest
+					currentMemory := currentResource.MemoryRequest
 
 					if recommendedCPU > currentCPU {
 						// We don't want to increase the CPU request for daemonsets


### PR DESCRIPTION
We want to not increase the resources for daemonset pod to prevent cases where 
- One pod in daemonset has a higher cpu usage which leads to increase of pod resource across the cluster
- Daemonset pods face scheduling challenges because of high resources. This can lead to node themselves getting into an unhealthy state since some daemonsets are mandatory for nodes to run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resource recommendations from increasing CPU requests for DaemonSet workloads beyond current values.
  * Prevented resource recommendations from increasing Memory requests for DaemonSet workloads beyond current values.
  * Ensured no additional leftover (unallocated) resources are assigned to DaemonSet containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->