### PR TITLE
set eviction ranking to disabled if workload has a do-not-disrupt ann…

### DIFF
--- a/pkg/task/taskCreateStats.go
+++ b/pkg/task/taskCreateStats.go
@@ -386,11 +386,14 @@ func (c *CreateStatsTask) prepareStatsFromMetrics(
 		workloadStat.Replicas = int32(workloadMetrics.MedianReplicas)
 	}
 
-	if workloadStat.Constraints != nil && workloadStat.Constraints.DoNotDisruptAnnotation {
+	switch {
+	case workloadStat.Constraints != nil && workloadStat.Constraints.DoNotDisruptAnnotation:
 		workloadStat.EvictionRanking = types.EvictionRankingDisabled
-	} else if workloadInfo.Kind == "StatefulSet" || workloadStat.Replicas == 1 {
+
+	case workloadInfo.Kind == "StatefulSet" || workloadStat.Replicas == 1:
 		workloadStat.EvictionRanking = types.EvictionRankingMedium
-	} else {
+
+	default:
 		workloadStat.EvictionRanking = types.EvictionRankingHigh
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workload protection via a do-not-disrupt annotation. Workloads marked with this annotation will no longer be subject to eviction, overriding standard eviction ranking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->