### PR TITLE
Clarify HPA limitations in CruiseKube documentation

### DIFF
--- a/docs/src/arch-tradeoffs.md
+++ b/docs/src/arch-tradeoffs.md
@@ -32,7 +32,7 @@ CruiseKube operates its own control loop, and when combined with other controlle
 
 Key limitations:
 
-* Workloads using CPU-based HPA are completely skipped by CruiseKube
+* Workloads using CPU or memory based HPA are completely skipped by CruiseKube
 * For other HPA modes, CruiseKube and HPA may influence the same workloads indirectly
 * Competing control loops can lead to oscillations or delayed convergence
 * Resource changes and replica scaling may interact in unexpected ways


### PR DESCRIPTION
Updated the limitations section to include memory-based HPA.

## Type of change

- [x] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that CruiseKube skips workloads using both CPU and memory-based Horizontal Pod Autoscaler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->