### PR TITLE
fix selector matching for pdbs and workloads

### DIFF
--- a/pkg/task/taskDisruptionForce.go
+++ b/pkg/task/taskDisruptionForce.go
@@ -130,34 +130,33 @@ func (t *DisruptionForceTask) Run(ctx context.Context) error {
 		selector, err := workloadObj.GetSelector()
 		if err != nil {
 			logging.Errorf(ctx, "Failed to get selector for workload %s/%s/%s: %v", stat.Kind, stat.Namespace, stat.Name, err)
-			continue
-		}
-
-		pods, err := utils.GetPods(ctx, t.kubeClient, stat.Namespace, selector)
-		if err != nil {
-			logging.Errorf(ctx, "Failed to list pods for workload %s/%s/%s: %v", stat.Kind, stat.Namespace, stat.Name, err)
-			continue
-		}
-
-		for i := range pods.Items {
-			pod := &pods.Items[i]
-
-			hasModifiedMarker := pod.Annotations != nil && pod.Annotations[utils.AnnotationModified] == utils.TrueValue
-			if !t.hasBlockingAnnotations(pod) && !hasModifiedMarker {
-				continue
-			}
-
-			modified, err := t.reconcilePod(ctx, pod, &workloadInfo, effectiveState)
+		} else {
+			pods, err := utils.GetPods(ctx, t.kubeClient, stat.Namespace, selector)
 			if err != nil {
-				logging.Errorf(ctx, "Failed to reconcile pod %s/%s: %v", pod.Namespace, pod.Name, err)
-				continue
-			}
-			if modified {
-				reconciledPods++
+				logging.Errorf(ctx, "Failed to list pods for workload %s/%s/%s: %v", stat.Kind, stat.Namespace, stat.Name, err)
+			} else {
+				for i := range pods.Items {
+					pod := &pods.Items[i]
+
+					hasModifiedMarker := pod.Annotations != nil && pod.Annotations[utils.AnnotationModified] == utils.TrueValue
+					if !t.hasBlockingAnnotations(pod) && !hasModifiedMarker {
+						continue
+					}
+
+					modified, err := t.reconcilePod(ctx, pod, &workloadInfo, effectiveState)
+					if err != nil {
+						logging.Errorf(ctx, "Failed to reconcile pod %s/%s: %v", pod.Namespace, pod.Name, err)
+						continue
+					}
+					if modified {
+						reconciledPods++
+					}
+				}
 			}
 		}
 
-		matchingPDBs := utils.FindMatchingPDBs(ctx, pods.Items, pdbsByNamespace[stat.Namespace])
+		podTemplate := utils.GetPodTemplateSpec(workloadObj)
+		matchingPDBs := utils.FindMatchingPDBs(ctx, podTemplate.Labels, pdbsByNamespace[stat.Namespace])
 		for _, pdb := range matchingPDBs {
 			modified, err := t.reconcilePDB(ctx, pdb, effectiveState)
 			if err != nil {
@@ -170,7 +169,7 @@ func (t *DisruptionForceTask) Run(ctx context.Context) error {
 		}
 	}
 
-	logging.Infof(ctx, "Total workloads with blocking annotations: %d", blockingCount)
+	logging.Infof(ctx, "Total workloads with blocking consolidation: %d", blockingCount)
 	logging.Infof(ctx, "Disruption force task completed: reconciled %d pods, %d PDBs modified", reconciledPods, reconciledPDBs)
 	return nil
 }

--- a/pkg/task/utils/workload_handler.go
+++ b/pkg/task/utils/workload_handler.go
@@ -478,7 +478,7 @@ func DetectWorkloadConstraints(ctx context.Context, kubeClient *kubernetes.Clien
 
 	constraints.PDB = checkWorkloadAgainstPDBs(ctx, workloadObj, pdbCache)
 
-	podTemplate := getPodTemplateSpec(workloadObj)
+	podTemplate := GetPodTemplateSpec(workloadObj)
 	if podTemplate != nil {
 		constraints.DoNotDisruptAnnotation = checkDoNotDisruptAnnotation(podTemplate)
 		constraints.Volume = checkVolumes(podTemplate)
@@ -510,7 +510,7 @@ func FetchPDBsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientse
 	return pdbCache, nil
 }
 
-func FindMatchingPDBs(ctx context.Context, pods []corev1.Pod, pdbs []policyv1.PodDisruptionBudget) []*policyv1.PodDisruptionBudget {
+func FindMatchingPDBs(ctx context.Context, podLabels labels.Set, pdbs []policyv1.PodDisruptionBudget) []*policyv1.PodDisruptionBudget {
 	var matching []*policyv1.PodDisruptionBudget
 	for i := range pdbs {
 		pdb := &pdbs[i]
@@ -522,18 +522,15 @@ func FindMatchingPDBs(ctx context.Context, pods []corev1.Pod, pdbs []policyv1.Po
 			logging.Errorf(ctx, "Error parsing PDB selector for %s/%s: %v", pdb.Namespace, pdb.Name, err)
 			continue
 		}
-		for _, pod := range pods {
-			if pdbSelector.Matches(labels.Set(pod.Labels)) {
-				matching = append(matching, pdb)
-				break
-			}
+		if pdbSelector.Matches(podLabels) {
+			matching = append(matching, pdb)
 		}
 	}
 	return matching
 }
 
 func checkWorkloadAgainstPDBs(ctx context.Context, workloadObj WorkloadObject, pdbCache map[string][]policyv1.PodDisruptionBudget) bool {
-	podTemplate := getPodTemplateSpec(workloadObj)
+	podTemplate := GetPodTemplateSpec(workloadObj)
 	if podTemplate == nil {
 		return false
 	}
@@ -558,7 +555,7 @@ func checkWorkloadAgainstPDBs(ctx context.Context, workloadObj WorkloadObject, p
 	return false
 }
 
-func getPodTemplateSpec(workloadObj WorkloadObject) *corev1.PodTemplateSpec {
+func GetPodTemplateSpec(workloadObj WorkloadObject) *corev1.PodTemplateSpec {
 	switch w := workloadObj.(type) {
 	case DeploymentWrapper:
 		return &w.Spec.Template


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod Disruption Budget matching now uses actual pod labels (improves accuracy of PDB detection for workloads).
  * Distinguishes pod-listing errors from per-pod reconciliation errors to reduce incorrect halt conditions.

* **Refactor**
  * Workload pod-template handling and constraint detection streamlined for more reliable PDB association.
  * Logging text updated to reference "consolidation" for clearer status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->