### PR TITLE
fix disruption force task stat constraint check

### DIFF
--- a/pkg/task/taskDisruptionForce.go
+++ b/pkg/task/taskDisruptionForce.go
@@ -146,10 +146,6 @@ func (t *DisruptionForceTask) Run(ctx context.Context) error {
 			}
 		}
 
-		if stat.Constraints.BlockingConsolidation && !stat.Constraints.PDB {
-			logging.Infof(ctx, "Skipping workload %s/%s/%s because it has blocking consolidation but no PDB", stat.Kind, stat.Namespace, stat.Name)
-		}
-
 		if stat.Constraints.DoNotDisruptAnnotation {
 			selector, err := workloadObj.GetSelector()
 			if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined workload skipping logic so disruption decisions target the correct workloads.
  * Restored per-pod reconciliation when protection annotations are present to avoid missed updates.

* **Improvements**
  * Introduced a separate PodDisruptionBudget (PDB) reconciliation path for clearer handling.
  * Improved error logging with more specific identifiers and more accurate reconciliation metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->