### PR TITLE
rounding memory and cpu recommendations before applying

### DIFF
--- a/pkg/task/taskApplyRecommendation.go
+++ b/pkg/task/taskApplyRecommendation.go
@@ -446,8 +446,6 @@ func (a *ApplyRecommendationTask) applyMemoryRecommendation(
 	// We use to set the max limit
 	allocatableCPU := 0.0
 	_, recommendedMemoryRequest, _, recommendedMemoryLimit := utils.ComputeRecommendedResourceValues(ctx, rec, allocatableCPU)
-	recommendedMemoryRequest = math.Round(recommendedMemoryRequest)
-	recommendedMemoryLimit = math.Round(recommendedMemoryLimit)
 
 	containerResource, err := rec.PodInfo.GetContainerResource(rec.ContainerName)
 	if err != nil {
@@ -532,8 +530,6 @@ func (a *ApplyRecommendationTask) applyCPURecommendation(
 	currentCPULimit := float64(currentCPULimitQuantity.MilliValue()) / 1000.0
 
 	recommendedCPURequest, _, recommendedCPULimit, _ := utils.ComputeRecommendedResourceValues(ctx, rec, allocatableCPU)
-	recommendedCPURequest = math.Round(recommendedCPURequest*1000) / 1000
-	recommendedCPULimit = math.Round(recommendedCPULimit*1000) / 1000
 	if currentCPULimit == 0.0 {
 		recommendedCPULimit = 0.0
 	}

--- a/pkg/task/utils/recommendation_apply.go
+++ b/pkg/task/utils/recommendation_apply.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"math"
 	"slices"
 	"time"
 
@@ -109,6 +110,11 @@ func ComputeRecommendedResourceValues(ctx context.Context, rec PodContainerRecom
 	} else {
 		logging.Warnf(ctx, "No stats for container %s", rec.ContainerName)
 	}
+
+	cpuRequest = math.Round(cpuRequest*1000) / 1000
+	cpuLimit = math.Round(cpuLimit*1000) / 1000
+	memoryRequest = math.Round(memoryRequest)
+	memoryLimit = math.Round(memoryLimit)
 	return cpuRequest, memoryRequest, cpuLimit, memoryLimit
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This changes the actual CPU/memory request/limit values applied to workloads by rounding CPU to 3 decimals and memory to whole numbers, which could slightly alter scheduling/limits in production. The logic is simple and localized to recommendation value computation.
> 
> **Overview**
> **Recommendation application now rounds resource values before returning them.** `ComputeRecommendedResourceValues` imports `math` and rounds CPU request/limit to 3 decimal places and memory request/limit to whole numbers, ensuring consistent, cleaner resource specs when applying recommendations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eb153de3b7be2ab2f214fc4d719bebaadbf3ca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consistency in resource recommendations with improved numerical precision: memory allocation values now round to the nearest whole number, while CPU allocation values round to three decimal places, providing clearer guidance for resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->