### PR TITLE
add sidecar containers to pod container resources

### DIFF
--- a/pkg/task/utils/node_stats_builder.go
+++ b/pkg/task/utils/node_stats_builder.go
@@ -175,6 +175,12 @@ func CreateNodeStatsMapping(
 				podInfo.ContainerResources = append(podInfo.ContainerResources, getCurrentContainerResources(&container))
 			}
 
+			for _, container := range pod.Spec.InitContainers {
+				if IsSidecarContainer(container) {
+					podInfo.ContainerResources = append(podInfo.ContainerResources, getCurrentContainerResources(&container))
+				}
+			}
+
 			nodeInfo.Pods = append(nodeInfo.Pods, podInfo)
 		}
 
@@ -363,6 +369,11 @@ func BuildPodInfoFromPod(pod *corev1.Pod, workloadInfo *WorkloadInfo, stat *Work
 	}
 	for i := range pod.Spec.Containers {
 		info.ContainerResources = append(info.ContainerResources, getCurrentContainerResources(&pod.Spec.Containers[i]))
+	}
+	for i := range pod.Spec.InitContainers {
+		if IsSidecarContainer(pod.Spec.InitContainers[i]) {
+			info.ContainerResources = append(info.ContainerResources, getCurrentContainerResources(&pod.Spec.InitContainers[i]))
+		}
 	}
 	return info
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how per-pod `ContainerResources` are computed by including init containers marked as sidecars, which can affect node/pod resource reporting and any downstream decisions (e.g., admission checks) based on these values.
> 
> **Overview**
> Pod `ContainerResources` now includes *sidecar init containers* (init containers with `RestartPolicyAlways`) in addition to regular containers.
> 
> This updates both node-level stats generation (`CreateNodeStatsMapping`) and admission-webhook pod info construction (`BuildPodInfoFromPod`) so sidecar init containers contribute per-container request/limit reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9530134f8c208e72d8d33ceece71d670749a7e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved container resource aggregation to include sidecar init containers in node-level resource calculations, ensuring more accurate resource usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->