### PR TITLE
add daemonset recommendation restriction for optimized but excluded case

### DIFF
--- a/pkg/task/taskApplyRecommendation.go
+++ b/pkg/task/taskApplyRecommendation.go
@@ -236,6 +236,11 @@ func (a *ApplyRecommendationTask) ApplyRecommendationsWithStrategy(
 				recommendedCPU, restCPU := strategy.GetRecommendedAndRestCPU(ctx, optimizableButExcludedPod, *containerStat)
 				recommendedMemory, restMemory := strategy.GetRecommendedAndRestMemory(ctx, optimizableButExcludedPod, *containerStat)
 
+				if optimizableButExcludedPod.WorkloadKind == utils.DaemonSetKind {
+					recommendedCPU = min(recommendedCPU, container.CPURequest)
+					restCPU = 0
+				}
+
 				recommendationResult.PodContainerRecommendations = append(recommendationResult.PodContainerRecommendations, utils.PodContainerRecommendation{
 					PodInfo:       optimizableButExcludedPod,
 					ContainerName: container.Name,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted change that only adjusts CPU values in generated recommendations for `DaemonSet` pods that are already excluded from application, reducing chances of recommending CPU increases.
> 
> **Overview**
> Prevents CPU recommendation increases for `DaemonSet` pods in the *optimizable-but-excluded* bucket by capping `recommendedCPU` at the container’s current CPU request and zeroing `restCPU` before emitting the dummy recommendation.
> 
> Memory recommendations and the main optimization/apply flow are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f31065904b383359067fa1c9189c507690e93914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted CPU recommendation calculations for DaemonSet workloads to clamp recommendations to the container's current CPU request, eliminating CPU rest allocation for these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->