### PR TITLE
Add Google Analytics configuration to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,9 @@ extra:
       link: https://github.com/truefoundry
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/truefoundry
+  analytics:
+    provider: google
+    property_id: G-M8EDCBCCHY
   structured_data:
     organization:
       "@context": "https://schema.org"


### PR DESCRIPTION
## Description
Add Google Analytics configuration to mkdocs.yml

## Type of change
Please delete options that are not relevant.

- [x] Documentation update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-site config change that only enables Google Analytics tracking; potential impact is limited to site telemetry/privacy expectations.
> 
> **Overview**
> Adds Google Analytics configuration to `mkdocs.yml` via `extra.analytics` (provider `google` with a GA4 `property_id`), enabling tracking on the generated documentation site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2df4ad1a642892d25581e23a9d75f2d62b6dc0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site configuration to enable analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->