### PR TITLE
Fix analytics property key in google tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ extra:
       link: https://x.com/truefoundry
   analytics:
     provider: google
-    property_id: G-M8EDCBCCHY
+    property: G-M8EDCBCCHY
   structured_data:
     organization:
       "@context": "https://schema.org"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it just updates the MkDocs Material analytics key name so tracking is correctly configured.
> 
> **Overview**
> Fixes the MkDocs Material Google Analytics configuration by renaming `extra.analytics.property_id` to `extra.analytics.property` in `mkdocs.yml`, keeping the same measurement ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d67f341757a6593c1e80cfc496c74e97ddd06b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google Analytics configuration identifier in documentation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->