### PR TITLE
Mi -> MB

### DIFF
--- a/docs/src/dev-cost.md
+++ b/docs/src/dev-cost.md
@@ -34,14 +34,14 @@ Based on the pricing from [Instance](https://instances.vantage.sh/aws/ec2/c5a.xl
 - The average price (or instance price) is what you pass in the frontend dashboard, and internally we do the below calculation.
 - We then assume half of the instance cost is for CPU and half for memory. So the effective rates used in the product are:
     - Price per core/hour = $0.029 ÷ 2 = $0.0145/hour
-    - Price per GB/hour = $0.0145 ÷ 2 = $0.00725/hour
+    - Price per GB/hour = $0.0145 ÷ 2 = $0.00724/hour
 
 ## Default prices
 
 | Resource | Default used in calculations |
 | --- | --- |
 | CPU | **0.0145** $/core/hour |
-| Memory | **0.00725** $/GB/hour |
+| Memory | **0.00724** $/GB/hour |
 
 ### What prices are used for
 

--- a/pkg/adapters/database/database_test.go
+++ b/pkg/adapters/database/database_test.go
@@ -97,7 +97,7 @@ func testStorage(t *testing.T, storage ports.Database) {
 	}
 
 	rows := []types.PodResourceRecommendationRow{
-		{WorkloadID: "Deployment/default/test-app/nginx", NodeName: "node-1", Namespace: "default", Pod: "test-app-abc", Container: "nginx", Recommendation: `{"cpu_request":0.5,"memory_request":512,"cpu_limit":1,"memory_limit":1024,"to_be_evicted":false}`},
+		{WorkloadID: "Deployment/default/test-app/nginx", NodeName: "node-1", Namespace: "default", Pod: "test-app-abc", Container: "nginx", Recommendation: `{"cpu_request":0.5,"memory_request":512,"cpu_limit":1,"memory_limit":1000,"to_be_evicted":false}`},
 		{WorkloadID: "Deployment/default/test-app/sidecar", NodeName: "node-1", Namespace: "default", Pod: "test-app-abc", Container: "sidecar", Recommendation: ""},
 	}
 	err = storage.SavePodRecommendations(clusterID, rows)

--- a/pkg/handlers/overview.go
+++ b/pkg/handlers/overview.go
@@ -132,8 +132,8 @@ func (deps HandlerDependencies) OverviewHandler(c *gin.Context) {
 	reqAllocRatioMem := dbRes.ReqAllocRatioMem
 
 	// Memory request/recommendation from workload stats are in MiB; convert to GiB to align with pricing units.
-	requestedMemGB := clusterReqMem / 1024
-	recommendedMemGB := clusterRecMem / 1024
+	requestedMemGB := clusterReqMem / 1000
+	recommendedMemGB := clusterRecMem / 1000
 
 	// Cost and savings mirror the summary API: current infra cost, current savings vs workload request, and possible savings vs recommendation.
 	currentCostDollars := (clusterRes.CPU.Allocatable*p.CPUPerCorePerHour + clusterRes.Memory.Allocatable*p.MemPerGBPerHour) * defaultHoursPerMonth

--- a/pkg/handlers/workload_summary.go
+++ b/pkg/handlers/workload_summary.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultCPUPricePerCorePerHour  = 0.0145
-	defaultMemoryPricePerGBPerHour = 0.00725
+	defaultMemoryPricePerGBPerHour = 0.00724
 	defaultHoursPerMonth           = 720
 )
 
@@ -251,7 +251,7 @@ func fillWorkloadDetailDollars(d *types.WorkloadDetail, agg workloadRecAgg, p wo
 	}
 	memSavings := 0.0
 	if totalCurrentMem > totalRecMem {
-		memSavings = (totalCurrentMem - totalRecMem) / 1024 * p.MemPerGBPerHour * defaultHoursPerMonth
+		memSavings = (totalCurrentMem - totalRecMem) / 1000 * p.MemPerGBPerHour * defaultHoursPerMonth
 	}
 	d.DollarSavingsPerMonth = cpuSavings + memSavings
 	cpuExpenditure := 0.0
@@ -260,7 +260,7 @@ func fillWorkloadDetailDollars(d *types.WorkloadDetail, agg workloadRecAgg, p wo
 	}
 	memExpenditure := 0.0
 	if totalRecMem > totalCurrentMem {
-		memExpenditure = (totalRecMem - totalCurrentMem) / 1024 * p.MemPerGBPerHour * defaultHoursPerMonth
+		memExpenditure = (totalRecMem - totalCurrentMem) / 1000 * p.MemPerGBPerHour * defaultHoursPerMonth
 	}
 	d.DollarExpenditurePerMonth = cpuExpenditure + memExpenditure
 }
@@ -378,8 +378,8 @@ func (deps HandlerDependencies) WorkloadSummaryHandler(c *gin.Context) {
 	if clusterRes.Memory.Allocatable > 0 {
 		reqAllocRatioMem = clusterRes.Memory.Requested / clusterRes.Memory.Allocatable
 	}
-	requestedMemGB := clusterReqMem / 1024
-	recommendedMemGB := clusterRecMem / 1024
+	requestedMemGB := clusterReqMem / 1000
+	recommendedMemGB := clusterRecMem / 1000
 	currentCostDollars := (clusterRes.CPU.Allocatable*p.CPUPerCorePerHour + clusterRes.Memory.Allocatable*p.MemPerGBPerHour) * defaultHoursPerMonth
 	workloadCostDollars := (clusterReqCPU/reqAllocRatioCpu)*p.CPUPerCorePerHour*defaultHoursPerMonth + (requestedMemGB/reqAllocRatioMem)*p.MemPerGBPerHour*defaultHoursPerMonth
 	optimizedCostDollars := (clusterRecCPU/reqAllocRatioCpu)*p.CPUPerCorePerHour*defaultHoursPerMonth + (recommendedMemGB/reqAllocRatioMem)*p.MemPerGBPerHour*defaultHoursPerMonth

--- a/test/e2e/manifest/postgres.yaml
+++ b/test/e2e/manifest/postgres.yaml
@@ -64,10 +64,10 @@ spec:
           mountPath: /docker-entrypoint-initdb.d
         resources:
           requests:
-            memory: "256Mi"
+            memory: "256MB"
             cpu: "100m"
           limits:
-            memory: "512Mi"
+            memory: "512MB"
             cpu: "500m"
         readinessProbe:
           exec:

--- a/test/e2e/tests/01-apply-recommendations/00-setup.yaml
+++ b/test/e2e/tests/01-apply-recommendations/00-setup.yaml
@@ -28,10 +28,10 @@ spec:
         - containerPort: 80
         resources:
           requests:
-            memory: "128Mi"
+            memory: "128MB"
             cpu: "500m"
           limits:
-            memory: "256Mi"
+            memory: "256MB"
             cpu: "1000m"
 ---
 apiVersion: apps/v1
@@ -57,8 +57,8 @@ spec:
         command: ["sh", "-c", "while true; do sleep 3600; done"]
         resources:
           requests:
-            memory: "64Mi"
+            memory: "64MB"
             cpu: "200m"
           limits:
-            memory: "128Mi"
+            memory: "128MB"
             cpu: "500m"

--- a/test/e2e/tests/02-webhook/00-setup.yaml
+++ b/test/e2e/tests/02-webhook/00-setup.yaml
@@ -28,10 +28,10 @@ spec:
         - containerPort: 6379
         resources:
           requests:
-            memory: "64Mi"
+            memory: "64MB"
             cpu: "100m"
           limits:
-            memory: "128Mi"
+            memory: "128MB"
             cpu: "200m"
 ---
 apiVersion: apps/v1
@@ -59,8 +59,8 @@ spec:
         - containerPort: 11211
         resources:
           requests:
-            memory: "32Mi"
+            memory: "32MB"
             cpu: "50m"
           limits:
-            memory: "64Mi"
+            memory: "64MB"
             cpu: "100m"

--- a/test/e2e/tests/03-oom-handling/00-setup.yaml
+++ b/test/e2e/tests/03-oom-handling/00-setup.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           import time
-          data = bytearray(800 * 1024 * 1024)  # 800MB
+          data = bytearray(800 * 1000 * 1000)  # 800MB
           print(f"Allocated 800MB, limit is 600MB")
           time.sleep(300)
         resources:

--- a/test/e2e/tests/03-oom-handling/02-assert.yaml
+++ b/test/e2e/tests/03-oom-handling/02-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 30
 ---
-# Original memory: 300Mi request, 600Mi limit
+# Original memory: 300MB request, 600MB limit
 # After OOM webhook should apply 600M request, 1200M limit
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes memory unit conversions and default pricing used in cost/savings calculations, which can materially alter reported costs and savings. Low code churn but affects user-visible financial metrics and test fixtures.
> 
> **Overview**
> **Cost and savings calculations now treat memory as decimal units.** The overview and workload summary handlers switch memory conversions from `/1024` to `/1000` when translating workload memory into GB for pricing, and dollar savings/expenditure math is updated accordingly.
> 
> **Defaults/tests/docs are aligned to the new unit basis.** The default memory price per GB-hour is adjusted (`0.00725` → `0.00724`), docs are updated to match, and e2e manifests plus a DB adapter test fixture update memory values (e.g., `Mi` → `MB`, and one recommendation `memory_limit` value) to keep assertions consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3c0185abd6b6e25c11e9009fc014a040d83880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documented memory pricing rate to reflect current cost calculations.

* **Bug Fixes**
  * Corrected memory unit conversions in cost and savings calculations to ensure accurate pricing estimates.
  * Adjusted default memory pricing constant to align with documented rates.

* **Tests**
  * Updated test fixtures with corrected memory unit formats and pricing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->