### PR TITLE
using the latest ratio for calculating original requested allocatable

### DIFF
--- a/pkg/handlers/overview.go
+++ b/pkg/handlers/overview.go
@@ -61,7 +61,7 @@ func (deps HandlerDependencies) getClusterResourcesFromDatabase(ctx context.Cont
 	if deps.Storage == nil {
 		return out
 	}
-	
+
 	endTime := time.Now().UTC()
 	startTime := endTime.AddDate(0, 0, -ratioLookbackDays)
 	snapshots, err := deps.Storage.GetSnapshotsInRange(clusterID, startTime, endTime)
@@ -113,6 +113,9 @@ func (deps HandlerDependencies) getClusterResourcesFromDatabase(ctx context.Cont
 	out.Resources.Memory.Requested = latest.Data.Memory.CurrentRequested
 	out.Resources.Memory.Utilised = latest.Data.Memory.CurrentUtilized
 
+	if latest.Data.CPU.CurrentAllocatable == 0 || latest.Data.Memory.CurrentAllocatable == 0 {
+		return out
+	}
 	out.ReqAllocRatioCPU = latest.Data.CPU.CurrentRequested / latest.Data.CPU.CurrentAllocatable
 	out.ReqAllocRatioMem = latest.Data.Memory.CurrentRequested / latest.Data.Memory.CurrentAllocatable
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the CPU/memory request-to-allocatable ratios used in cost/savings calculations from a 7-day sampled average to the latest snapshot, which can materially affect reported costs and savings but is localized to the overview handler.
> 
> **Overview**
> Updates `getClusterResourcesFromDatabase` to stop averaging request/allocatable ratios over recent snapshots and instead derive `ReqAllocRatioCPU`/`ReqAllocRatioMem` from the most recent snapshot only.
> 
> Adds a zero-allocatable guard before computing these ratios, while continuing to source current allocatable/requested/utilised values from the latest snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeb7310e19d599e5858d047a4f8e7c9024d2e59d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Cluster CPU and memory allocation ratio calculations now use the latest resource snapshot so displayed ratios reflect current state.
  * Ratios are omitted when allocatable CPU or memory is zero to avoid presenting invalid or misleading values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->