### PR TITLE
fix: request > limit fix | set max to limit between request and limit

### DIFF
--- a/pkg/task/utils/recommendation_apply.go
+++ b/pkg/task/utils/recommendation_apply.go
@@ -103,7 +103,10 @@ func ComputeRecommendedResourceValues(ctx context.Context, rec PodContainerRecom
 			if containerStat.MemoryStats != nil && containerStat.MemoryStats.OOMMemory > 0 {
 				oom = containerStat.MemoryStats.OOMMemory
 			}
-			memoryLimit = EnforceMinimumMemory(max(memMax, oom) * 2)
+			// Keep derived memory limit from 7-day/OOM signal, but never let it
+			// drop below the chosen memory request, otherwise Kubernetes rejects
+			// the pod update (request must be <= limit).
+			memoryLimit = max(memoryRequest, EnforceMinimumMemory(max(memMax, oom)*2))
 		}
 	} else {
 		logging.Warnf(ctx, "No stats for container %s", rec.ContainerName)
@@ -111,6 +114,11 @@ func ComputeRecommendedResourceValues(ctx context.Context, rec PodContainerRecom
 
 	cpuRequest = math.Round(cpuRequest*1000) / 1000
 	cpuLimit = math.Round(cpuLimit*1000) / 1000
+	// If we are setting a CPU limit, ensure it is never below request.
+	// Kubernetes validates request <= limit for the same resource.
+	if cpuLimit > 0 {
+		cpuLimit = max(cpuLimit, cpuRequest)
+	}
 	memoryRequest = math.Round(memoryRequest)
 	memoryLimit = math.Round(memoryLimit)
 	return cpuRequest, memoryRequest, cpuLimit, memoryLimit

--- a/pkg/task/utils/recommendation_apply_test.go
+++ b/pkg/task/utils/recommendation_apply_test.go
@@ -41,3 +41,56 @@ func TestShouldGenerateRecommendationRejectsIncompleteStats(t *testing.T) {
 		t.Fatalf("expected incomplete-stats reason, got %q", reason)
 	}
 }
+
+func TestComputeRecommendedResourceValuesKeepsMemoryLimitAtLeastRequest(t *testing.T) {
+	rec := PodContainerRecommendation{
+		ContainerName: "main",
+		CPU:           1,
+		Memory:        1014,
+		PodInfo: PodInfo{
+			Stats: &WorkloadStat{
+				ContainerStats: []ContainerStats{
+					{
+						ContainerName: "main",
+						MemoryStats: &MemoryStats{
+							OOMMemory: 0,
+						},
+						Memory7Day: &Memory7DayStats{
+							Max: 255,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, memoryRequest, _, memoryLimit := ComputeRecommendedResourceValues(context.Background(), rec, 4)
+	if memoryLimit < memoryRequest {
+		t.Fatalf("expected memory limit >= memory request, got limit=%v request=%v", memoryLimit, memoryRequest)
+	}
+	if memoryRequest != 1014 {
+		t.Fatalf("expected memory request to be 1014MB, got %v", memoryRequest)
+	}
+	if memoryLimit != 1014 {
+		t.Fatalf("expected memory limit to be clamped to request (1014MB), got %v", memoryLimit)
+	}
+}
+
+func TestComputeRecommendedResourceValuesKeepsCPULimitAtLeastRequestWhenSet(t *testing.T) {
+	rec := PodContainerRecommendation{
+		ContainerName: "main",
+		CPU:           2.5,
+		Memory:        256,
+	}
+
+	cpuRequest, _, cpuLimit, _ := ComputeRecommendedResourceValues(context.Background(), rec, 1.0)
+	if cpuRequest != 2.5 {
+		t.Fatalf("expected cpu request to be 2.5, got %v", cpuRequest)
+	}
+	if cpuLimit < cpuRequest {
+		t.Fatalf("expected cpu limit >= cpu request, got limit=%v request=%v", cpuLimit, cpuRequest)
+	}
+	if cpuLimit != 2.5 {
+		t.Fatalf("expected cpu limit to be clamped to request (2.5), got %v", cpuLimit)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small validation/clamping change to resource recommendation math, covered by new unit tests; main impact is slightly higher limits in edge cases.
> 
> **Overview**
> Prevents invalid recommendation applications by ensuring computed `memoryLimit` is clamped to at least `memoryRequest` (even when 7-day/OOM-derived limit would be lower) and `cpuLimit` is clamped to at least `cpuRequest` when a CPU limit is set.
> 
> Adds unit tests covering both edge cases to guard against Kubernetes `request <= limit` validation failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5034a3f7fc08b938ed568d56d10d715828e5a4a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource recommendations to enforce Kubernetes validity constraints. Memory limits are now bounded to not fall below memory requests, and CPU limits are clamped to be at least CPU requests, ensuring `request ≤ limit` relationships.

* **Tests**
  * Added unit tests to verify proper enforcement of resource request-limit constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->