### PR TITLE
Fetch workload overrides from database instead of API in apply recommendation task

### DIFF
--- a/pkg/task/taskapplyrecommendation.go
+++ b/pkg/task/taskapplyrecommendation.go
@@ -124,6 +124,9 @@ func (a *ApplyRecommendationTask) Run(ctx context.Context) error {
 			logging.Warnf(ctx, "Skipping workload %s: missing stat", workload.WorkloadID)
 			continue
 		}
+		if stat.IsGPUWorkload() {
+			continue
+		}
 		overridesMap[workload.WorkloadID] = &types.WorkloadOverrideInfo{
 			WorkloadID: workload.WorkloadID,
 			Name:       stat.Name,

--- a/pkg/task/taskapplyrecommendation.go
+++ b/pkg/task/taskapplyrecommendation.go
@@ -111,20 +111,22 @@ func (a *ApplyRecommendationTask) Run(ctx context.Context) error {
 	}
 	logging.Infof(ctx, "Loaded %d node recommendations", len(nodeRecommendationMap))
 
-	recommenderClient := client.NewRecommenderServiceClientWithBasicAuth(
-		a.config.Metadata.NodeStatsURL.Host,
-		a.config.BasicAuth.Username,
-		a.config.BasicAuth.Password,
-	)
-	workloadOverrides, err := recommenderClient.ListWorkloads(ctx, a.config.ClusterID)
+	workloads, err := a.storage.GetWorkloadsInCluster(a.config.ClusterID)
 	if err != nil {
-		logging.Errorf(ctx, "Error loading workload overrides from client: %v", err)
-		return fmt.Errorf("failed to list workloads from recommender service: %w", err)
+		logging.Errorf(ctx, "Error loading workloads from storage: %v", err)
+		return fmt.Errorf("failed to get workloads from storage: %w", err)
 	}
 
 	overridesMap := make(map[string]*types.WorkloadOverrideInfo)
-	for _, override := range workloadOverrides {
-		overridesMap[override.WorkloadID] = &override
+	for _, workload := range workloads {
+		stat := workload.GetStat()
+		overridesMap[workload.WorkloadID] = &types.WorkloadOverrideInfo{
+			WorkloadID: workload.WorkloadID,
+			Name:       stat.Name,
+			Namespace:  stat.Namespace,
+			Kind:       stat.Kind,
+			Overrides:  workload.OverridesWithDefaults(),
+		}
 	}
 
 	supportsMemoryLimitReduction := utils.CheckIfClusterVersionAbove(ctx, a.config.ClusterID, a.kubeClient, 1, 34)

--- a/pkg/task/taskapplyrecommendation.go
+++ b/pkg/task/taskapplyrecommendation.go
@@ -121,7 +121,11 @@ func (a *ApplyRecommendationTask) Run(ctx context.Context) error {
 	for _, workload := range workloads {
 		stat := workload.GetStat()
 		if stat == nil {
-			logging.Warnf(ctx, "Skipping workload %s: missing stat", workload.WorkloadID)
+			logging.Warnf(ctx, "Workload %s has no stat; using stored overrides without stat metadata", workload.WorkloadID)
+			overridesMap[workload.WorkloadID] = &types.WorkloadOverrideInfo{
+				WorkloadID: workload.WorkloadID,
+				Overrides:  workload.OverridesWithDefaults(),
+			}
 			continue
 		}
 		if stat.IsGPUWorkload() {

--- a/pkg/task/taskapplyrecommendation.go
+++ b/pkg/task/taskapplyrecommendation.go
@@ -121,11 +121,7 @@ func (a *ApplyRecommendationTask) Run(ctx context.Context) error {
 	for _, workload := range workloads {
 		stat := workload.GetStat()
 		if stat == nil {
-			logging.Warnf(ctx, "Workload %s has no stat; using stored overrides without stat metadata", workload.WorkloadID)
-			overridesMap[workload.WorkloadID] = &types.WorkloadOverrideInfo{
-				WorkloadID: workload.WorkloadID,
-				Overrides:  workload.OverridesWithDefaults(),
-			}
+			logging.Warnf(ctx, "Workload %s has no stat; skipping (same as list-workloads API)", workload.WorkloadID)
 			continue
 		}
 		if stat.IsGPUWorkload() {

--- a/pkg/task/taskapplyrecommendation.go
+++ b/pkg/task/taskapplyrecommendation.go
@@ -120,6 +120,10 @@ func (a *ApplyRecommendationTask) Run(ctx context.Context) error {
 	overridesMap := make(map[string]*types.WorkloadOverrideInfo)
 	for _, workload := range workloads {
 		stat := workload.GetStat()
+		if stat == nil {
+			logging.Warnf(ctx, "Skipping workload %s: missing stat", workload.WorkloadID)
+			continue
+		}
 		overridesMap[workload.WorkloadID] = &types.WorkloadOverrideInfo{
 			WorkloadID: workload.WorkloadID,
 			Name:       stat.Name,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses INFRA-459 by modifying the `ApplyRecommendationTask` to fetch workload overrides from the database instead of making an external API call.

## Changes

- Modified `pkg/task/taskapplyrecommendation.go`:
  - Replaced `recommenderClient.ListWorkloads()` API call with `storage.GetWorkloadsInCluster()` database query
  - Updated the logic to convert `WorkloadInCluster` objects to `WorkloadOverrideInfo` map format
  - Removed the unnecessary `recommenderClient` initialization for workload overrides

## Benefits

- Reduces external API dependencies during the apply recommendation task
- Improves performance by eliminating network calls
- Ensures consistency by using the same data source (database) that other parts of the system use
- Aligns with the architecture where the database is the source of truth for workload overrides

## Testing

- All existing tests pass
- The project builds successfully
- No breaking changes to the API or data structures
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://truefoundryworkspace.slack.com/archives/D0ARJE39NHE/p1775206255637529?thread_ts=1775206255.637529&cid=D0ARJE39NHE)

<div><a href="https://cursor.com/agents/bc-30a9a714-7e79-4656-a66b-13217ed67b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30a9a714-7e79-4656-a66b-13217ed67b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overrides are now sourced directly from cluster storage instead of an external service, improving reliability and performance.
  * Error messages and logs now reference storage failures.
  * Workloads missing status are skipped with a warning (no override applied).
  * GPU workloads are skipped to avoid improper overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->