### PR TITLE
Add a issue type for adopters

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter.yaml
+++ b/.github/ISSUE_TEMPLATE/adopter.yaml
@@ -1,0 +1,48 @@
+name: Add us to Adopters
+description: Get listed as a CruiseKube adopter (helps motivate OSS work)
+title: "[ADOPTER] <your org/team name>"
+labels:
+  - adopters
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using **CruiseKube**.
+        
+        Adding your team as an adopter helps us stay motivated to keep investing in open source, and it adds credibility for new teams evaluating the project.
+        
+        If you prefer not to share details publicly, you can keep the description brief.
+
+  - type: input
+    id: name
+    attributes:
+      label: Organization / team name
+      placeholder: "Acme Corp (Platform Team)"
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Website (optional)
+      placeholder: "https://acme.com"
+    validations:
+      required: false
+
+  - type: textarea
+    id: usage
+    attributes:
+      label: How are you using CruiseKube?
+      description: One or two sentences is perfect (e.g. workloads, clusters, modes).
+      placeholder: "Using CruiseKube in Recommend mode across our production clusters to continuously right-size CPU/memory requests for microservices."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Consent
+      options:
+        - label: I confirm the information above is OK to publish in the CruiseKube adopters.
+          required: true
+


### PR DESCRIPTION
This will make is easy for users to add themselves to the adopters list. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds GitHub metadata only and does not affect runtime code or behavior.
> 
> **Overview**
> Adds a new GitHub issue template (`.github/ISSUE_TEMPLATE/adopter.yaml`) to collect adopter submissions, including org name, optional website, brief usage description, and explicit consent for publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b074523c8cb8d2eb4e339b3e023eda9a20012ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a GitHub issue template for collecting adopter information, enabling organizations to submit their usage details for potential inclusion in the adopters list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->