### PR TITLE
pre-fetching all pods before matching pod to workloads

### DIFF
--- a/pkg/handlers/killswitch.go
+++ b/pkg/handlers/killswitch.go
@@ -109,7 +109,7 @@ func (deps HandlerDependencies) analyzeAndKillPods(ctx context.Context, kubeClie
 			continue
 		}
 
-		hasResourceDiff, reason := comparePodWithWorkload(ctx, kubeClient, pod, workloadObj)
+		hasResourceDiff, reason := comparePodWithWorkload(ctx, pod, workloadObj)
 		if hasResourceDiff {
 			success, evictErr := utils.EvictPod(ctx, kubeClient, pod)
 
@@ -142,9 +142,9 @@ func (deps HandlerDependencies) analyzeAndKillPods(ctx context.Context, kubeClie
 	return podsAnalyzed, podsKilled, killedPods, errors
 }
 
-func comparePodWithWorkload(ctx context.Context, kubeClient *kubernetes.Clientset, pod *corev1.Pod, workload utils.WorkloadObject) (bool, string) {
-	workloadContainers := workload.GetContainerSpecs(ctx, kubeClient)
-	workloadInitContainers := workload.GetInitContainerSpecs(ctx, kubeClient)
+func comparePodWithWorkload(ctx context.Context, pod *corev1.Pod, workload utils.WorkloadObject) (bool, string) {
+	workloadContainers := workload.GetContainerSpecs(ctx, map[string][]corev1.Pod{})
+	workloadInitContainers := workload.GetInitContainerSpecs(ctx, map[string][]corev1.Pod{})
 
 	allContainers := make([]corev1.Container, 0, len(workloadContainers)+len(workloadInitContainers))
 	allContainers = append(allContainers, workloadContainers...)

--- a/pkg/task/taskcreatestats.go
+++ b/pkg/task/taskcreatestats.go
@@ -147,6 +147,12 @@ func (c *CreateStatsTask) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch PDBs for namespaces: %w", err)
 	}
 
+	podCache, err := utils.FetchPodsForNamespaces(ctx, c.kubeClient, namespaces)
+	if err != nil {
+		logging.Errorf(ctx, "Error fetching Pods: %v", err)
+		return fmt.Errorf("failed to fetch Pods for namespaces: %w", err)
+	}
+
 	// namespaceVsWorkloadPredictions := map[string]map[string]contextutils.WorkloadPrediction{}
 
 	var newStats []*utils.WorkloadStat
@@ -164,6 +170,7 @@ func (c *CreateStatsTask) Run(ctx context.Context) error {
 			workloadHpaMemoryMap,
 			c.dynamicClient,
 			pdbCache,
+			podCache,
 		); stat != nil {
 			newStats = append(newStats, stat)
 		}
@@ -230,9 +237,10 @@ func (c *CreateStatsTask) prepareStatsFromMetrics(
 	workloadHpaMemoryMap map[string]bool,
 	dynamicClient dynamic.Interface,
 	pdbCache map[string][]policyv1.PodDisruptionBudget,
+	podCache map[string][]corev1.Pod,
 ) *utils.WorkloadStat {
-	containerSpecs := workloadObject.GetContainerSpecs(ctx, kubeClient)
-	initContainerSpecs := workloadObject.GetInitContainerSpecs(ctx, kubeClient)
+	containerSpecs := workloadObject.GetContainerSpecs(ctx, podCache)
+	initContainerSpecs := workloadObject.GetInitContainerSpecs(ctx, podCache)
 
 	containerResources := c.getAllContainerResourcesFromContainerSpecs(ctx, containerSpecs, initContainerSpecs)
 	workloadStat := c.buildBaseWorkloadStat(workloadKey, workloadObject, containerResources, nsVsWorkloadMetrics)

--- a/pkg/task/taskcreatestats_test.go
+++ b/pkg/task/taskcreatestats_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/truefoundry/cruisekube/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 )
 
 type fakeWorkloadObject struct {
@@ -20,10 +19,10 @@ type fakeWorkloadObject struct {
 func (f fakeWorkloadObject) GetKind() string      { return utils.DeploymentKind }
 func (f fakeWorkloadObject) GetNamespace() string { return "ns" }
 func (f fakeWorkloadObject) GetName() string      { return "app" }
-func (f fakeWorkloadObject) GetContainerSpecs(context.Context, *kubernetes.Clientset) []corev1.Container {
+func (f fakeWorkloadObject) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	return nil
 }
-func (f fakeWorkloadObject) GetInitContainerSpecs(context.Context, *kubernetes.Clientset) []corev1.Container {
+func (f fakeWorkloadObject) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	return nil
 }
 func (f fakeWorkloadObject) GetSelector() (labels.Selector, error) { return labels.Everything(), nil }

--- a/pkg/task/utils/util.go
+++ b/pkg/task/utils/util.go
@@ -527,7 +527,7 @@ func GetMatchingPodsFromPodCache(ctx context.Context, podCache map[string][]core
 	}
 	matchingPods := []corev1.Pod{}
 	for _, pod := range podsInNamespace {
-		if selector.Matches(labels.Merge(pod.Labels, make(labels.Set))) {
+		if selector.Matches(labels.Set(pod.Labels)) {
 			matchingPods = append(matchingPods, pod)
 		}
 	}

--- a/pkg/task/utils/util.go
+++ b/pkg/task/utils/util.go
@@ -520,17 +520,18 @@ func GetPods(ctx context.Context, kubeClient *kubernetes.Clientset, namespace st
 	return pods, nil
 }
 
-func GetMatchingPodFromPodCache(ctx context.Context, podCache map[string][]corev1.Pod, namespace string, selector labels.Selector) *corev1.Pod {
+func GetMatchingPodsFromPodCache(ctx context.Context, podCache map[string][]corev1.Pod, namespace string, selector labels.Selector) []corev1.Pod {
 	podsInNamespace, ok := podCache[namespace]
 	if !ok || len(podsInNamespace) == 0 {
-		return nil
+		return []corev1.Pod{}
 	}
+	matchingPods := []corev1.Pod{}
 	for _, pod := range podsInNamespace {
 		if selector.Matches(labels.Merge(pod.Labels, make(labels.Set))) {
-			return &pod
+			matchingPods = append(matchingPods, pod)
 		}
 	}
-	return nil
+	return matchingPods
 }
 
 func GetWorkloadPodSpec(ctx context.Context, kubeClient *kubernetes.Clientset, workloadInfo *WorkloadInfo) (*corev1.PodTemplateSpec, error) {

--- a/pkg/task/utils/util.go
+++ b/pkg/task/utils/util.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -518,6 +519,19 @@ func GetPods(ctx context.Context, kubeClient *kubernetes.Clientset, namespace st
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
 	return pods, nil
+}
+
+func GetMatchingPodFromPodCache(ctx context.Context, podCache map[string][]v1.Pod, namespace string, selector labels.Selector) *v1.Pod {
+	podsInNamespace, ok := podCache[namespace]
+	if !ok || len(podsInNamespace) == 0 {
+		return nil
+	}
+	for _, pod := range podsInNamespace {
+		if selector.Matches(labels.Merge(pod.Labels, make(labels.Set))) {
+			return &pod
+		}
+	}
+	return nil
 }
 
 func GetWorkloadPodSpec(ctx context.Context, kubeClient *kubernetes.Clientset, workloadInfo *WorkloadInfo) (*corev1.PodTemplateSpec, error) {

--- a/pkg/task/utils/util.go
+++ b/pkg/task/utils/util.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -521,7 +520,7 @@ func GetPods(ctx context.Context, kubeClient *kubernetes.Clientset, namespace st
 	return pods, nil
 }
 
-func GetMatchingPodFromPodCache(ctx context.Context, podCache map[string][]v1.Pod, namespace string, selector labels.Selector) *v1.Pod {
+func GetMatchingPodFromPodCache(ctx context.Context, podCache map[string][]corev1.Pod, namespace string, selector labels.Selector) *corev1.Pod {
 	podsInNamespace, ok := podCache[namespace]
 	if !ok || len(podsInNamespace) == 0 {
 		return nil

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,8 +50,8 @@ type WorkloadObject interface {
 	GetKind() string
 	GetNamespace() string
 	GetName() string
-	GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container
-	GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container
+	GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container
+	GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container
 	GetSelector() (labels.Selector, error)
 	GetCreationTime() time.Time
 	GetReplicas() int32
@@ -68,7 +67,7 @@ func (d DeploymentWrapper) GetKind() string {
 	return DeploymentKind
 }
 
-func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := d.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
@@ -82,7 +81,7 @@ func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache m
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	containers := d.Spec.Template.Spec.Containers
 	selector, err := d.GetSelector()
 	if err != nil {
@@ -133,7 +132,7 @@ func (s StatefulSetWrapper) GetKind() string {
 	return StatefulSetKind
 }
 
-func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := s.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
@@ -147,7 +146,7 @@ func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache 
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	containers := s.Spec.Template.Spec.Containers
 	selector, err := s.GetSelector()
 	if err != nil {
@@ -198,7 +197,7 @@ func (d DaemonSetWrapper) GetKind() string {
 	return DaemonSetKind
 }
 
-func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := s.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
@@ -212,7 +211,7 @@ func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache ma
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (s DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+func (s DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	containers := s.Spec.Template.Spec.Containers
 	selector, err := s.GetSelector()
 	if err != nil {
@@ -574,8 +573,8 @@ func checkWorkloadAgainstPDBs(ctx context.Context, workloadObj WorkloadObject, p
 	return false
 }
 
-func FetchPodsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientset, namespaces []string) (map[string][]v1.Pod, error) {
-	podCache := make(map[string][]v1.Pod)
+func FetchPodsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientset, namespaces []string) (map[string][]corev1.Pod, error) {
+	podCache := make(map[string][]corev1.Pod)
 
 	for _, namespace := range namespaces {
 		podList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -68,18 +68,20 @@ func (d DeploymentWrapper) GetKind() string {
 }
 
 func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
+	workloadContainers := d.Spec.Template.Spec.InitContainers
 	selector, err := d.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
-		return d.Spec.Template.Spec.InitContainers
+		return workloadContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.InitContainers
 	}
-	return pods[0].Spec.InitContainers
+	return mergeContainers(workloadContainers, podContainers)
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -90,13 +92,13 @@ func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[s
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
 		return containers
 	}
-
+	
 	// getting pods as dynamically injected containers might not be tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.Containers
 	}
-	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 
@@ -137,19 +139,21 @@ func (s StatefulSetWrapper) GetKind() string {
 }
 
 func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
+	workloadContainers := s.Spec.Template.Spec.InitContainers
 	selector, err := s.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for statefulset %s/%s: %v", s.Namespace, s.Name, err)
-		return s.Spec.Template.Spec.InitContainers
+		return workloadContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.InitContainers
 	}
 
-	return pods[0].Spec.InitContainers
+	return mergeContainers(workloadContainers, podContainers)
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -163,11 +167,10 @@ func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.Containers
 	}
-
-	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 
@@ -208,19 +211,21 @@ func (d DaemonSetWrapper) GetKind() string {
 }
 
 func (d DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
+	workloadContainers := d.Spec.Template.Spec.InitContainers
 	selector, err := d.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for daemonset %s/%s: %v", d.Namespace, d.Name, err)
-		return d.Spec.Template.Spec.InitContainers
+		return workloadContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.InitContainers
 	}
 
-	return pods[0].Spec.InitContainers
+	return mergeContainers(workloadContainers, podContainers)
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -234,11 +239,10 @@ func (d DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[st
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
-	if len(pods) == 0 {
-		return []corev1.Container{}
+	podContainers := []corev1.Container{}
+	if len(pods) > 0 {
+		podContainers = pods[0].Spec.Containers
 	}
-
-	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -92,7 +92,7 @@ func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[s
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
 		return containers
 	}
-	
+
 	// getting pods as dynamically injected containers might not be tracked in workload spec
 	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
 	podContainers := []corev1.Container{}

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -207,15 +207,15 @@ func (d DaemonSetWrapper) GetKind() string {
 	return DaemonSetKind
 }
 
-func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
-	selector, err := s.GetSelector()
+func (d DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
+	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
-		return s.Spec.Template.Spec.InitContainers
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
+		return d.Spec.Template.Spec.InitContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
 	if len(pods) == 0 {
 		return []corev1.Container{}
 	}
@@ -224,16 +224,16 @@ func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache ma
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (s DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
-	containers := s.Spec.Template.Spec.Containers
-	selector, err := s.GetSelector()
+func (d DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
+	containers := d.Spec.Template.Spec.Containers
+	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
 		return containers
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
 	if len(pods) == 0 {
 		return []corev1.Container{}
 	}

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -210,7 +210,7 @@ func (d DaemonSetWrapper) GetKind() string {
 func (d DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for daemonSet %s/%s: %v", d.Namespace, d.Name, err)
+		logging.Errorf(ctx, "Error getting selector for daemonset %s/%s: %v", d.Namespace, d.Name, err)
 		return d.Spec.Template.Spec.InitContainers
 	}
 
@@ -228,7 +228,7 @@ func (d DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[st
 	containers := d.Spec.Template.Spec.Containers
 	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for daemonSet %s/%s: %v", d.Namespace, d.Name, err)
+		logging.Errorf(ctx, "Error getting selector for daemonset %s/%s: %v", d.Namespace, d.Name, err)
 		return containers
 	}
 
@@ -591,14 +591,19 @@ func checkWorkloadAgainstPDBs(ctx context.Context, workloadObj WorkloadObject, p
 
 func FetchPodsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientset, namespaces []string) (map[string][]corev1.Pod, error) {
 	podCache := make(map[string][]corev1.Pod)
+	failedNamespaces := make([]string, 0)
 
 	for _, namespace := range namespaces {
 		podList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			logging.Warnf(ctx, "Error listing Pods for namespace %s: %v", namespace, err)
+			failedNamespaces = append(failedNamespaces, namespace)
 			continue
 		}
 		podCache[namespace] = podList.Items
+	}
+	if len(failedNamespaces) > 0 {
+		return podCache, fmt.Errorf("failed to prefetch pods for namespaces: %s", strings.Join(failedNamespaces, ", "))
 	}
 
 	return podCache, nil

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -75,9 +75,11 @@ func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache m
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, d.Namespace, selector)
-
-	return pod.Spec.InitContainers
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
+	return pods[0].Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -90,9 +92,11 @@ func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[s
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, d.Namespace, selector)
-
-	podContainers := pod.Spec.Containers
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, d.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
+	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 
@@ -140,9 +144,12 @@ func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache 
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
 
-	return pod.Spec.InitContainers
+	return pods[0].Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -155,9 +162,12 @@ func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
 
-	podContainers := pod.Spec.Containers
+	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 
@@ -205,9 +215,12 @@ func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache ma
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
 
-	return pod.Spec.InitContainers
+	return pods[0].Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
@@ -220,9 +233,12 @@ func (s DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[st
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
+	pods := GetMatchingPodsFromPodCache(ctx, podCache, s.Namespace, selector)
+	if len(pods) == 0 {
+		return []corev1.Container{}
+	}
 
-	podContainers := pod.Spec.Containers
+	podContainers := pods[0].Spec.Containers
 	return mergeContainers(containers, podContainers)
 }
 

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -139,7 +139,7 @@ func (s StatefulSetWrapper) GetKind() string {
 func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		logging.Errorf(ctx, "Error getting selector for statefulset %s/%s: %v", s.Namespace, s.Name, err)
 		return s.Spec.Template.Spec.InitContainers
 	}
 
@@ -157,7 +157,7 @@ func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[
 	containers := s.Spec.Template.Spec.Containers
 	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		logging.Errorf(ctx, "Error getting selector for statefulset %s/%s: %v", s.Namespace, s.Name, err)
 		return containers
 	}
 
@@ -210,7 +210,7 @@ func (d DaemonSetWrapper) GetKind() string {
 func (d DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]corev1.Pod) []corev1.Container {
 	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
+		logging.Errorf(ctx, "Error getting selector for daemonSet %s/%s: %v", d.Namespace, d.Name, err)
 		return d.Spec.Template.Spec.InitContainers
 	}
 
@@ -228,7 +228,7 @@ func (d DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[st
 	containers := d.Spec.Template.Spec.Containers
 	selector, err := d.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
+		logging.Errorf(ctx, "Error getting selector for daemonSet %s/%s: %v", d.Namespace, d.Name, err)
 		return containers
 	}
 

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,8 +51,8 @@ type WorkloadObject interface {
 	GetKind() string
 	GetNamespace() string
 	GetName() string
-	GetContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container
-	GetInitContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container
+	GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container
+	GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container
 	GetSelector() (labels.Selector, error)
 	GetCreationTime() time.Time
 	GetReplicas() int32
@@ -67,7 +68,7 @@ func (d DeploymentWrapper) GetKind() string {
 	return DeploymentKind
 }
 
-func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
+func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
 	selector, err := d.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
@@ -75,36 +76,25 @@ func (d DeploymentWrapper) GetInitContainerSpecs(ctx context.Context, kubeClient
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, d.Namespace, selector)
-	if err != nil || len(pods.Items) == 0 {
-		logging.Warnf(ctx, "Could not get pods for deployment %s/%s, falling back to template: %v", d.Namespace, d.Name, err)
-		return d.Spec.Template.Spec.InitContainers
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, d.Namespace, selector)
 
-	return pods.Items[0].Spec.InitContainers
+	return pod.Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
-	workload := d.Spec.Template.Spec.Containers
+func (d DeploymentWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+	containers := d.Spec.Template.Spec.Containers
 	selector, err := d.GetSelector()
 	if err != nil {
 		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
+		return containers
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, d.Namespace, selector)
-	if err != nil {
-		logging.Errorf(ctx, "Error getting pods for deployment %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
-	}
-	if len(pods.Items) == 0 {
-		return workload
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, d.Namespace, selector)
 
-	podContainers := pods.Items[0].Spec.Containers
-	return mergeContainers(workload, podContainers)
+	podContainers := pod.Spec.Containers
+	return mergeContainers(containers, podContainers)
 }
 
 func (d DeploymentWrapper) GetSelector() (labels.Selector, error) {
@@ -143,44 +133,33 @@ func (s StatefulSetWrapper) GetKind() string {
 	return StatefulSetKind
 }
 
-func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
+func (s StatefulSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
 	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for statefulset %s/%s: %v", s.Namespace, s.Name, err)
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
 		return s.Spec.Template.Spec.InitContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, s.Namespace, selector)
-	if err != nil || len(pods.Items) == 0 {
-		logging.Warnf(ctx, "Could not get pods for statefulset %s/%s, falling back to template: %v", s.Namespace, s.Name, err)
-		return s.Spec.Template.Spec.InitContainers
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
 
-	return pods.Items[0].Spec.InitContainers
+	return pod.Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (d StatefulSetWrapper) GetContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
-	workload := d.Spec.Template.Spec.Containers
-	selector, err := d.GetSelector()
+func (s StatefulSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+	containers := s.Spec.Template.Spec.Containers
+	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for statefulset %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		return containers
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, d.Namespace, selector)
-	if err != nil {
-		logging.Errorf(ctx, "Error getting pods for statefulset %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
-	}
-	if len(pods.Items) == 0 {
-		return workload
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
 
-	podContainers := pods.Items[0].Spec.Containers
-	return mergeContainers(workload, podContainers)
+	podContainers := pod.Spec.Containers
+	return mergeContainers(containers, podContainers)
 }
 
 func (s StatefulSetWrapper) GetSelector() (labels.Selector, error) {
@@ -219,44 +198,33 @@ func (d DaemonSetWrapper) GetKind() string {
 	return DaemonSetKind
 }
 
-func (d DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
-	selector, err := d.GetSelector()
+func (s DaemonSetWrapper) GetInitContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for daemonset %s/%s: %v", d.Namespace, d.Name, err)
-		return d.Spec.Template.Spec.InitContainers
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		return s.Spec.Template.Spec.InitContainers
 	}
 
 	// getting fresh pods as dynamically injected containers are not tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, d.Namespace, selector)
-	if err != nil || len(pods.Items) == 0 {
-		logging.Warnf(ctx, "Could not get pods for daemonset %s/%s, falling back to template: %v", d.Namespace, d.Name, err)
-		return d.Spec.Template.Spec.InitContainers
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
 
-	return pods.Items[0].Spec.InitContainers
+	return pod.Spec.InitContainers
 }
 
 // GetContainerSpecs returns workload container specs plus any from the pod not in the spec (e.g. dynamically injected).
-func (d DaemonSetWrapper) GetContainerSpecs(ctx context.Context, kubeClient *kubernetes.Clientset) []corev1.Container {
-	workload := d.Spec.Template.Spec.Containers
-	selector, err := d.GetSelector()
+func (s DaemonSetWrapper) GetContainerSpecs(ctx context.Context, podCache map[string][]v1.Pod) []corev1.Container {
+	containers := s.Spec.Template.Spec.Containers
+	selector, err := s.GetSelector()
 	if err != nil {
-		logging.Errorf(ctx, "Error getting selector for daemonset %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
+		logging.Errorf(ctx, "Error getting selector for deployment %s/%s: %v", s.Namespace, s.Name, err)
+		return containers
 	}
 
 	// getting pods as dynamically injected containers might not be tracked in workload spec
-	pods, err := GetPods(ctx, kubeClient, d.Namespace, selector)
-	if err != nil {
-		logging.Errorf(ctx, "Error getting pods for daemonset %s/%s: %v", d.Namespace, d.Name, err)
-		return workload
-	}
-	if len(pods.Items) == 0 {
-		return workload
-	}
+	pod := GetMatchingPodFromPodCache(ctx, podCache, s.Namespace, selector)
 
-	podContainers := pods.Items[0].Spec.Containers
-	return mergeContainers(workload, podContainers)
+	podContainers := pod.Spec.Containers
+	return mergeContainers(containers, podContainers)
 }
 
 func (d DaemonSetWrapper) GetSelector() (labels.Selector, error) {
@@ -604,6 +572,21 @@ func checkWorkloadAgainstPDBs(ctx context.Context, workloadObj WorkloadObject, p
 	}
 
 	return false
+}
+
+func FetchPodsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientset, namespaces []string) (map[string][]v1.Pod, error) {
+	podCache := make(map[string][]v1.Pod)
+
+	for _, namespace := range namespaces {
+		podList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logging.Warnf(ctx, "Error listing Pods for namespace %s: %v", namespace, err)
+			continue
+		}
+		podCache[namespace] = podList.Items
+	}
+
+	return podCache, nil
 }
 
 func GetPodTemplateSpec(workloadObj WorkloadObject) *corev1.PodTemplateSpec {

--- a/pkg/task/utils/workloadhandler.go
+++ b/pkg/task/utils/workloadhandler.go
@@ -535,14 +535,19 @@ func DetectWorkloadConstraints(ctx context.Context, kubeClient *kubernetes.Clien
 
 func FetchPDBsForNamespaces(ctx context.Context, kubeClient *kubernetes.Clientset, namespaces []string) (map[string][]policyv1.PodDisruptionBudget, error) {
 	pdbCache := make(map[string][]policyv1.PodDisruptionBudget)
+	failedNamespaces := make([]string, 0)
 
 	for _, namespace := range namespaces {
 		pdbList, err := kubeClient.PolicyV1().PodDisruptionBudgets(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			logging.Warnf(ctx, "Error listing PodDisruptionBudgets for namespace %s: %v", namespace, err)
+			failedNamespaces = append(failedNamespaces, namespace)
 			continue
 		}
 		pdbCache[namespace] = pdbList.Items
+	}
+	if len(failedNamespaces) > 0 {
+		return pdbCache, fmt.Errorf("failed to prefetch pdbs for namespaces: %s", strings.Join(failedNamespaces, ", "))
 	}
 
 	return pdbCache, nil


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how container specs are derived (template + first matching pod from a pre-fetched cache) and makes `CreateStats` fail if pod/PDB prefetch partially fails, which could alter eviction decisions or task reliability across namespaces.
> 
> **Overview**
> Reduces per-workload Kubernetes API calls by **pre-fetching all Pods per namespace** and passing a `podCache` through stats generation and workload wrappers, so `GetContainerSpecs`/`GetInitContainerSpecs` merge workload templates with containers observed on a matching Pod (to capture dynamically injected containers).
> 
> Updates the `WorkloadObject` interface and all wrappers (Deployment/StatefulSet/DaemonSet), adjusts `killswitch` resource comparison to the new signature, and tightens prefetch behavior so `FetchPDBsForNamespaces`/new `FetchPodsForNamespaces` return an error when any namespace list call fails (while still returning partial caches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76654e70568b9c305fab4b041aca41ec2397c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Eviction and resource comparisons now derive container and init-container specs from workload templates plus a pre-fetched per-namespace pod cache (pods fetched once per namespace), reducing live API queries while preserving eviction and audit behavior.
* **Tests**
  * Test suite updated to use the cache-driven spec retrieval approach and new pod-cache helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->