### PR TITLE
fix: release workflow error

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -15,11 +15,12 @@ permissions:
 jobs:
   build-operator:
     name: Build and Push Docker Images
-    uses: truefoundry/workflows/.github/workflows/build.yml@main
+    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
@@ -28,8 +29,7 @@ jobs:
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-      secret_image_build_args: |
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,9 +1,6 @@
 name: Push image to JFROG Public
 
 on:
-  pull_request:
-    branches:
-      - 'main'
   push:
     branches:
       - 'main'

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -20,7 +20,7 @@ jobs:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY="123"
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -11,14 +11,25 @@ permissions:
 
 
 jobs:
+  get-secret:
+    runs-on: ubuntu-latest
+      outputs:
+        posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.CRUISE_KUBE_CI_SECRET }}
   build-operator:
     name: Build and Push Docker Images
+    needs: [get-secret]
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.get-secret.outputs.posthog_api_key }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -12,9 +12,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  POSTHOG_API_KEY: ${{ vars.POSTHOG_API_KEY }}
-
 jobs:
   build-operator:
     name: Build and Push Docker Images
@@ -23,7 +20,7 @@ jobs:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ env.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
@@ -32,6 +29,7 @@ jobs:
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -12,20 +12,16 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  USAGETELEMETRY_PROVIDER_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
 
 jobs:
   build-operator:
     name: Build and Push Docker Images
-    env:
-      USAGETELEMETRY_PROVIDER_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,6 +1,9 @@
 name: Push image to JFROG Public
 
 on:
+  pull_request:
+    branches:
+      - 'main'
   push:
     branches:
       - 'main'
@@ -17,7 +20,7 @@ jobs:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY="123"
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -13,19 +13,13 @@ permissions:
   contents: read
 
 jobs:
-  build-values:
-    runs-on: ubuntu-latest
-    outputs:
-      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
   build-operator:
     name: Build and Push Docker Images
-    needs: [build-values]
-    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
+    uses: truefoundry/workflows/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.build-values.outputs.posthog_api_key }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
@@ -34,6 +28,8 @@ jobs:
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      secret_image_build_args: |
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
   
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -12,6 +12,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  POSTHOG_API_KEY: ${{ vars.POSTHOG_API_KEY }}
+
 jobs:
   build-operator:
     name: Build and Push Docker Images
@@ -20,7 +23,7 @@ jobs:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ env.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -30,7 +30,6 @@ jobs:
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -13,14 +13,19 @@ permissions:
   contents: read
 
 jobs:
+  build-values:
+  runs-on: ubuntu-latest
+    outputs:
+      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
   build-operator:
     name: Build and Push Docker Images
+    needs: [build-values]
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.build-values.outputs.posthog_api_key }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
@@ -29,7 +34,6 @@ jobs:
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-values:
-  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     outputs:
       posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
   build-operator:

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -18,7 +18,8 @@ env:
 jobs:
   build-operator:
     name: Build and Push Docker Images
-    
+    env:
+      USAGETELEMETRY_PROVIDER_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -12,9 +12,13 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  USAGETELEMETRY_PROVIDER_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+
 jobs:
   build-operator:
     name: Build and Push Docker Images
+    
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -11,25 +11,14 @@ permissions:
 
 
 jobs:
-  get-secret:
-    runs-on: ubuntu-latest
-      outputs:
-        posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: "0"
-          token: ${{ secrets.CRUISE_KUBE_CI_SECRET }}
   build-operator:
     name: Build and Push Docker Images
-    needs: [get-secret]
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
       image_build_args: |
         VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.get-secret.outputs.posthog_api_key }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release cruisekube Helm Chart
 
 on:  
-  pull_request:
-    branches:
-      - 'main'
   push:
     tags:
       - v*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
       chart_name: ${{ steps.read_chart.outputs.CHART_NAME }}
       cruisekube_tag: ${{ steps.read_chart.outputs.cruisekube_TAG }}
       cruisekube_frontend_tag: ${{ steps.read_chart.outputs.cruisekube_frontend_TAG }}
-      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Release cruisekube Helm Chart
 
-on:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
+on:      
+  pull_request:
+    branches:
+      - 'main'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
   push:
     tags:
       - v*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
       chart_name: ${{ steps.read_chart.outputs.CHART_NAME }}
       cruisekube_tag: ${{ steps.read_chart.outputs.cruisekube_TAG }}
       cruisekube_frontend_tag: ${{ steps.read_chart.outputs.cruisekube_frontend_TAG }}
-      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -66,7 +65,7 @@ jobs:
       image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
       image_build_args: |
         VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.read-chart-values.outputs.posthog_api_key }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: "cruisekube"
       dockerfile_path: "Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Release cruisekube Helm Chart
 
-on:
+on:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
   push:
     tags:
       - v*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release cruisekube Helm Chart
 
-on:      
-  pull_request:
-    branches:
-      - 'main'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+on:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
   push:
     tags:
       - v*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Release cruisekube Helm Chart
 
-on:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
+on:  
+  pull_request:
+    branches:
+      - 'main'
   push:
     tags:
       - v*
@@ -21,6 +24,7 @@ jobs:
       chart_name: ${{ steps.read_chart.outputs.CHART_NAME }}
       cruisekube_tag: ${{ steps.read_chart.outputs.cruisekube_TAG }}
       cruisekube_frontend_tag: ${{ steps.read_chart.outputs.cruisekube_frontend_TAG }}
+      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
       chart_name: ${{ steps.read_chart.outputs.CHART_NAME }}
       cruisekube_tag: ${{ steps.read_chart.outputs.cruisekube_TAG }}
       cruisekube_frontend_tag: ${{ steps.read_chart.outputs.cruisekube_frontend_TAG }}
+      posthog_api_key: ${{ secrets.POSTHOG_API_KEY }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -63,9 +64,9 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
-      image_build_args: | 
+      image_build_args: |
         VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ needs.read-chart-values.outputs.posthog_api_key }}
       image_artifact_name: "cruisekube"
       dockerfile_path: "Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG USAGETELEMETRY_PROVIDER_API_KEY=
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
-	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}}" \
+	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ COPY ./pkg ./pkg
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
+ARG USAGETELEMETRY_PROVIDER_API_KEY=
 
-ENV USAGETELEMETRY_PROVIDER_API_KEY=
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
-	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
+	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}}" \
 	-o cruisekube ./cmd/cruisekube
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY ./pkg ./pkg
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
-ARG USAGETELEMETRY_PROVIDER_API_KEY=
 
+ARG USAGETELEMETRY_PROVIDER_API_KEY=
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
 	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./pkg ./pkg
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
 
-ARG USAGETELEMETRY_PROVIDER_API_KEY=
+ENV USAGETELEMETRY_PROVIDER_API_KEY=
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
 	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions build/release workflows, so misconfiguration could break image publishing or tagged releases. Changes are small and limited to workflow YAML and build args wiring.
> 
> **Overview**
> Fixes the `release.yaml` workflow trigger syntax (corrects the malformed `on` block) so tag-based releases run properly.
> 
> Updates both `build-n-publish.yml` and `release.yaml` to pass `USAGETELEMETRY_PROVIDER_API_KEY` from GitHub `vars.POSTHOG_API_KEY` instead of `secrets.POSTHOG_API_KEY` when building Docker images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d335309268d7ba0cfc7ef68874cc1c57241c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/deploy workflow to also run for pull requests targeting main and to forward the analytics API key into the shared build job for consistent telemetry during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->