### PR TITLE
Rt/hotfix release usage 3

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -16,12 +16,12 @@ permissions:
 jobs:
   build-operator:
     name: Build and Push Docker Images
-    env:
-      VERSION: ${{ github.sha }}
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: |
+          USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+          VERSION=${{ github.sha }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -19,7 +19,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: "VERSION=${{ github.sha }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}"
+      image_build_args: "USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }} VERSION=${{ github.sha }} "
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,9 +1,6 @@
 name: Push image to JFROG Public
 
 on:
-  pull_request:
-    branches:
-      - 'main'
   push:
     branches:
       - 'main'

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,6 +1,9 @@
 name: Push image to JFROG Public
 
 on:
+  pull_request:
+    branches:
+      - 'main'
   push:
     branches:
       - 'main'

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -14,23 +14,71 @@ permissions:
 
 
 jobs:
+  # Inlined (not github-workflows-public build.yml): that workflow passes
+  # build-args: ${{ toJSON(inputs.image_build_args) }}, which JSON-escapes newlines.
+  # docker/build-push-action expects newline-delimited KEY=VAL lines; a single JSON
+  # string merges lines into the first arg (API key value gets "\nVERSION=…", VERSION stays default dev).
   build-operator:
     name: Build and Push Docker Images
-    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
-    with:
-      image_tag: ${{ github.sha }}
-      image_build_args: |
-          USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
-          VERSION=${{ github.sha }}
-      image_artifact_name: 'cruisekube'
-      dockerfile_path: 'Dockerfile'
-      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
-      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
-      platforms: 'linux/amd64'
-    secrets:
-      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-  
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      IMAGE_TAG: ${{ github.sha }}
+      IMAGE_ARTIFACT_NAME: "cruisekube"
+      DOCKERFILE_PATH: "Dockerfile"
+      IMAGE_CONTEXT: "."
+      ARTIFACTORY_REGISTRY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      ARTIFACTORY_REPOSITORY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      PLATFORMS: "linux/amd64"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate registry configuration
+        run: |
+          if [ -z "$ARTIFACTORY_REGISTRY_URL" ] || [ -z "$ARTIFACTORY_REPOSITORY_URL" ]; then
+            echo "Error: Artifactory registry or repository URL is not set"
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to JFrog Artifactory
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ARTIFACTORY_REGISTRY_URL }}
+          username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+          password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+
+      - name: Prepare image tags
+        id: prepare_tags
+        run: |
+          FULL_IMAGE_NAME="${ARTIFACTORY_REPOSITORY_URL}/${IMAGE_ARTIFACT_NAME}"
+          IMAGE_WITH_TAG="${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+          echo "image=${IMAGE_WITH_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${FULL_IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "Image: ${IMAGE_WITH_TAG}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.prepare_tags.outputs.image }}
+          cache-from: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache,mode=max,image-manifest=true,compression=zstd
+          build-args: |
+            USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+            VERSION=${{ github.sha }}
+
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:
     name: Build and Push cruisekube-frontend Docker Images

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -1,6 +1,9 @@
 name: Push image to JFROG Public
 
 on:
+  pull_request:
+    branches:
+      - 'main'
   push:
     branches:
       - 'main'
@@ -16,7 +19,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: "USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }} --build-arg VERSION=${{ github.sha }}"
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -19,7 +19,9 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: VERSION=${{ github.sha }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: |
+        VERSION=${{ github.sha }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -19,7 +19,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: "USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }} VERSION=${{ github.sha }} "
+      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -76,7 +76,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache
           cache-to: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache,mode=max,image-manifest=true,compression=zstd
           build-args: |
-            USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+            USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
             VERSION=${{ github.sha }}
 
   # Build and push cruisekube-frontend image

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -19,9 +19,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: |
-        VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: "VERSION=${{ github.sha }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}"
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -16,9 +16,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: |
-        VERSION=${{ github.sha }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: VERSION=${{ github.sha }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -16,10 +16,12 @@ permissions:
 jobs:
   build-operator:
     name: Build and Push Docker Images
+    env:
+      VERSION: ${{ github.sha }}
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      image_build_args: "USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }} --build-arg VERSION=${{ github.sha }}"
+      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: 'cruisekube'
       dockerfile_path: 'Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
-      image_build_args: |
-        VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: "cruisekube"
       dockerfile_path: "Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,7 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
-      image_build_args: |
-        VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
-        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: "cruisekube"
       dockerfile_path: "Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,9 @@ jobs:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     with:
       image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
-      image_build_args: VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }} USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
+      image_build_args: |
+        VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
       image_artifact_name: "cruisekube"
       dockerfile_path: "Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,21 +56,77 @@ jobs:
           echo "cruisekube tag: $cruisekube_TAG"
           echo "cruisekube-frontend tag: $cruisekube_frontend_TAG"
 
-  # Build and push cruisekube image
+  # Inlined (not github-workflows-public build.yml): that workflow passes
+  # build-args through toJSON(), which breaks multiline KEY=VAL lists for docker/build-push-action.
   build-cruisekube:
     name: Build and Push cruisekube Docker Images
     needs: [read-chart-values]
-    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
-    with:
-      image_tag: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
-      image_build_args: USAGETELEMETRY_PROVIDER_API_KEY=${{ vars.POSTHOG_API_KEY }}
-      image_artifact_name: "cruisekube"
-      dockerfile_path: "Dockerfile"
-      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
-      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
-    secrets:
-      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      IMAGE_TAG: ${{ needs.read-chart-values.outputs.cruisekube_tag }}
+      IMAGE_ARTIFACT_NAME: "cruisekube"
+      DOCKERFILE_PATH: "Dockerfile"
+      IMAGE_CONTEXT: "."
+      ARTIFACTORY_REGISTRY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      ARTIFACTORY_REPOSITORY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      PLATFORMS: "linux/amd64,linux/arm64"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          submodules: "recursive"
+          token: ${{ secrets.CRUISE_KUBE_CI_SECRET }}
+
+      - name: Validate registry configuration
+        run: |
+          if [ -z "$ARTIFACTORY_REGISTRY_URL" ] || [ -z "$ARTIFACTORY_REPOSITORY_URL" ]; then
+            echo "Error: Artifactory registry or repository URL is not set"
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to JFrog Artifactory
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ARTIFACTORY_REGISTRY_URL }}
+          username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+          password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+
+      - name: Prepare image tags
+        id: prepare_tags
+        run: |
+          FULL_IMAGE_NAME="${ARTIFACTORY_REPOSITORY_URL}/${IMAGE_ARTIFACT_NAME}"
+          IMAGE_WITH_TAG="${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+          echo "image=${IMAGE_WITH_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${FULL_IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "Image: ${IMAGE_WITH_TAG}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.prepare_tags.outputs.image }}
+          cache-from: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache,mode=max,image-manifest=true,compression=zstd
+          build-args: |
+            USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+            VERSION=${{ needs.read-chart-values.outputs.cruisekube_tag }}
+
+      - name: Output image digest
+        run: |
+          echo "Image digest for ${{ steps.prepare_tags.outputs.image }} has been pushed successfully"
 
   # Build and push cruisekube-frontend image
   build-cruisekube-frontend:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./pkg ./pkg
 
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
-ENV VERSION=dev
+ARG VERSION=dev
 ARG USAGETELEMETRY_PROVIDER_API_KEY
 RUN if [ -n "${VERSION}" ]; then echo "build: version (VERSION build-arg): present"; else echo "build: version (VERSION build-arg): empty"; fi && \
 	if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY ./pkg ./pkg
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
 ARG USAGETELEMETRY_PROVIDER_API_KEY=""
-RUN if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi
+RUN if [ -n "${VERSION}" ]; then echo "build: version (VERSION build-arg): present"; else echo "build: version (VERSION build-arg): empty"; fi && \
+	if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ ARG VERSION=dev
 
 ARG USAGETELEMETRY_PROVIDER_API_KEY=
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
-	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
-	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
+	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM public.ecr.aws/docker/library/golang:1.25.9-alpine3.23 AS builder
-RUN apk add --no-cache git gcc musl-dev
+RUN apk add --no-cache git gcc musl-dev sqlite-dev
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,17 @@ COPY ./pkg ./pkg
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
-ARG USAGETELEMETRY_PROVIDER_API_KEY=""
+ARG USAGETELEMETRY_PROVIDER_API_KEY
 RUN if [ -n "${VERSION}" ]; then echo "build: version (VERSION build-arg): present"; else echo "build: version (VERSION build-arg): empty"; fi && \
 	if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi
-RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
-	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
-	-o cruisekube ./cmd/cruisekube
+
+RUN CGO_ENABLED=1 GOOS=linux go build -a \
+    -ldflags "\
+        -s -w \
+        -X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
+        -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
+    -o cruisekube \
+    ./cmd/cruisekube
 
 # Runtime stage
 FROM public.ecr.aws/docker/library/alpine:3.23

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM public.ecr.aws/docker/library/golang:1.25.9-alpine3.23 AS builder
-RUN apk add --no-cache git gcc musl-dev sqlite-dev
+RUN apk add --no-cache git gcc musl-dev
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ COPY ./pkg ./pkg
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
-
-ARG USAGETELEMETRY_PROVIDER_API_KEY=
+ARG USAGETELEMETRY_PROVIDER_API_KEY
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
-	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
+	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
+	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ COPY ./pkg ./pkg
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
-ARG USAGETELEMETRY_PROVIDER_API_KEY
+ARG USAGETELEMETRY_PROVIDER_API_KEY=""
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
-	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} \
-	-X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
+	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY ./pkg ./pkg
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
 ARG USAGETELEMETRY_PROVIDER_API_KEY=""
+RUN if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/truefoundry/cruisekube/pkg/buildmetadata.Version=${VERSION} -X github.com/truefoundry/cruisekube/pkg/buildmetadata.DefaultUsageTelemetryProviderAPIKey=${USAGETELEMETRY_PROVIDER_API_KEY}" \
 	-o cruisekube ./cmd/cruisekube

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./pkg ./pkg
 
 # Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
 # release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
-ARG VERSION=dev
+ENV VERSION=dev
 ARG USAGETELEMETRY_PROVIDER_API_KEY
 RUN if [ -n "${VERSION}" ]; then echo "build: version (VERSION build-arg): present"; else echo "build: version (VERSION build-arg): empty"; fi && \
 	if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,8 @@ RUN go mod download
 COPY ./cmd ./cmd
 COPY ./pkg ./pkg
 
-# Baked into the API (e.g. /config version). CI passes VERSION to match the image tag:
-# release: charts/cruisekube/values.yaml cruisekubeController.image.tag; main: github.sha.
 ARG VERSION=dev
 ARG USAGETELEMETRY_PROVIDER_API_KEY
-RUN if [ -n "${VERSION}" ]; then echo "build: version (VERSION build-arg): present"; else echo "build: version (VERSION build-arg): empty"; fi && \
-	if [ -n "${USAGETELEMETRY_PROVIDER_API_KEY}" ]; then echo "build: usage telemetry provider api key: present"; else echo "build: usage telemetry provider api key: empty"; fi
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a \
     -ldflags "\

--- a/charts/cruisekube/templates/NOTES.txt
+++ b/charts/cruisekube/templates/NOTES.txt
@@ -22,16 +22,15 @@ Read the generated admin password:
   kubectl get secret {{ include "cruisekubeController.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data['{{ .Values.cruisekubeController.admin.passwordKey }}']}" | base64 -d && echo
 
 If you used helm install --dry-run, these commands apply after a real install once the hook Job has created the Secret.
-{{- end }}
 
 ---
+{{- end }}
+
 
 {{- $ut := .Values.cruisekubeController.usageTelemetry | default dict }}
 {{- if and .Values.cruisekubeController.enabled ($ut.enabled | default false) }}
 
 Usage telemetry is enabled: the controller sends anonymous periodic heartbeats to help improve CruiseKube. A stable install identifier is stored in Secret {{ include "cruisekubeController.runtimeDataSecretName" . }} (key {{ include "cruisekubeController.runtimeDataSecretInstallIdKey" . }}). To turn this off, set cruisekubeController.usageTelemetry.enabled to false and upgrade the release.
-{{- end }}
 
 ---
-
-
+{{- end }}

--- a/cmd/cruisekube/runtime.go
+++ b/cmd/cruisekube/runtime.go
@@ -5,11 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
-	"github.com/truefoundry/cruisekube/pkg/buildmetadata"
 	"github.com/truefoundry/cruisekube/pkg/config"
 	"github.com/truefoundry/cruisekube/pkg/logging"
 	"github.com/truefoundry/cruisekube/pkg/server"
@@ -70,33 +67,12 @@ func loadRuntimeConfig(ctx context.Context) (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Validate(ctx); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	logUsageTelemetryKeySources(ctx, cfg)
 	logging.Infof(ctx, "Configuration loaded: controllerMode=%s executionMode=%s", cfg.ControllerMode, cfg.ExecutionMode)
 	return cfg, nil
-}
-
-func logUsageTelemetryKeySources(ctx context.Context, cfg *config.Config) {
-	if cfg == nil {
-		return
-	}
-
-	_, envKeyPresent := os.LookupEnv("CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY")
-	cfgKeyPresent := strings.TrimSpace(cfg.UsageTelemetry.ProviderAPIKey) != ""
-	bakedKeyPresent := strings.TrimSpace(buildmetadata.DefaultUsageTelemetryProviderAPIKey) != ""
-	effectiveKeyPresent := strings.TrimSpace(cfg.EffectiveUsageTelemetryProviderAPIKey()) != ""
-
-	logging.Infof(
-		ctx,
-		"Usage telemetry key sources: env_present=%t config_present=%t baked_present=%t effective_present=%t",
-		envKeyPresent,
-		cfgKeyPresent,
-		bakedKeyPresent,
-		effectiveKeyPresent,
-	)
 }
 
 func setupSentry(ctx context.Context, cfg *config.Config) {

--- a/cmd/cruisekube/runtime.go
+++ b/cmd/cruisekube/runtime.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/truefoundry/cruisekube/pkg/buildmetadata"
 	"github.com/truefoundry/cruisekube/pkg/config"
 	"github.com/truefoundry/cruisekube/pkg/logging"
 	"github.com/truefoundry/cruisekube/pkg/server"
@@ -71,8 +74,29 @@ func loadRuntimeConfig(ctx context.Context) (*config.Config, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	logUsageTelemetryKeySources(ctx, cfg)
 	logging.Infof(ctx, "Configuration loaded: controllerMode=%s executionMode=%s", cfg.ControllerMode, cfg.ExecutionMode)
 	return cfg, nil
+}
+
+func logUsageTelemetryKeySources(ctx context.Context, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+
+	_, envKeyPresent := os.LookupEnv("CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY")
+	cfgKeyPresent := strings.TrimSpace(cfg.UsageTelemetry.ProviderAPIKey) != ""
+	bakedKeyPresent := strings.TrimSpace(buildmetadata.DefaultUsageTelemetryProviderAPIKey) != ""
+	effectiveKeyPresent := strings.TrimSpace(cfg.EffectiveUsageTelemetryProviderAPIKey()) != ""
+
+	logging.Infof(
+		ctx,
+		"Usage telemetry key sources: env_present=%t config_present=%t baked_present=%t effective_present=%t",
+		envKeyPresent,
+		cfgKeyPresent,
+		bakedKeyPresent,
+		effectiveKeyPresent,
+	)
 }
 
 func setupSentry(ctx context.Context, cfg *config.Config) {

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -13,6 +13,8 @@ import (
 	"github.com/truefoundry/cruisekube/pkg/logging"
 )
 
+const defaultUsageTelemetryInterval = "30m"
+
 // LoadWithViperInstance loads configuration using a provided Viper instance (for flag binding).
 func LoadWithViperInstance(ctx context.Context, v *viper.Viper, configFilePath string) (*Config, error) {
 	// Set defaults matching the new structure
@@ -40,7 +42,7 @@ func LoadWithViperInstance(ctx context.Context, v *viper.Viper, configFilePath s
 	v.SetDefault("telemetry.enabled", false)
 	v.SetDefault("telemetry.traceRatio", 0.1)
 	v.SetDefault("usageTelemetry.enabled", false)
-	v.SetDefault("usageTelemetry.interval", "30m")
+	v.SetDefault("usageTelemetry.interval", defaultUsageTelemetryInterval)
 	v.SetDefault("usageTelemetry.installID", "")
 	v.SetDefault("usageTelemetry.helmChartVersion", "")
 
@@ -121,17 +123,17 @@ func usageTelemetryStringFromMap(m map[string]interface{}, key string) string {
 	}
 }
 
-func (c *Config) Validate() error {
+func (c *Config) Validate(ctx context.Context) error {
 	switch c.ExecutionMode {
 	case ExecutionModeWebhook:
-		return c.ValidateWebhookExecutionMode()
+		return c.ValidateWebhookExecutionMode(ctx)
 	case ExecutionModeController:
-		return c.ValidateControllerExecutionMode()
+		return c.ValidateControllerExecutionMode(ctx)
 	case ExecutionModeBoth:
-		if err := c.ValidateWebhookExecutionMode(); err != nil {
+		if err := c.ValidateWebhookExecutionMode(ctx); err != nil {
 			return err
 		}
-		if err := c.ValidateControllerExecutionMode(); err != nil {
+		if err := c.ValidateControllerExecutionMode(ctx); err != nil {
 			return err
 		}
 		return nil
@@ -140,7 +142,7 @@ func (c *Config) Validate() error {
 	}
 }
 
-func (c *Config) ValidateWebhookExecutionMode() error {
+func (c *Config) ValidateWebhookExecutionMode(ctx context.Context) error {
 	var missing []string
 	if c.Webhook.Port == "" {
 		missing = append(missing, "webhook.port")
@@ -158,7 +160,7 @@ func (c *Config) ValidateWebhookExecutionMode() error {
 	return nil
 }
 
-func (c *Config) ValidateControllerExecutionMode() error {
+func (c *Config) ValidateControllerExecutionMode(ctx context.Context) error {
 	controllerMode := strings.TrimSpace(string(c.ControllerMode))
 	switch controllerMode {
 	case string(ClusterModeLocal):
@@ -183,41 +185,41 @@ func (c *Config) ValidateControllerExecutionMode() error {
 		return fmt.Errorf("missing required controller task configurations: %s", strings.Join(missingTaskConfigs, ", "))
 	}
 
-	return c.validateUsageTelemetryForController()
+	return c.validateUsageTelemetryForController(ctx)
 }
 
-func (c *Config) validateUsageTelemetryForController() error {
+func (c *Config) validateUsageTelemetryForController(ctx context.Context) error {
 	if !c.UsageTelemetry.Enabled {
 		return nil
 	}
 	interval := strings.TrimSpace(c.UsageTelemetry.Interval)
 	if interval == "" {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval is empty; defaulting to 30m")
-		c.UsageTelemetry.Interval = "30m"
-		interval = "30m"
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but interval is empty; defaulting to %s", defaultUsageTelemetryInterval)
+		c.UsageTelemetry.Interval = defaultUsageTelemetryInterval
+		interval = defaultUsageTelemetryInterval
 	}
 	d, err := time.ParseDuration(interval)
 	if err != nil {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval %q is invalid (%v); defaulting to 30m", c.UsageTelemetry.Interval, err)
-		c.UsageTelemetry.Interval = "30m"
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but interval %q is invalid (%v); defaulting to %s", c.UsageTelemetry.Interval, err, defaultUsageTelemetryInterval)
+		c.UsageTelemetry.Interval = defaultUsageTelemetryInterval
 		d = 30 * time.Minute
 	}
 	if d <= 0 {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval %q is non-positive; defaulting to 30m", c.UsageTelemetry.Interval)
-		c.UsageTelemetry.Interval = "30m"
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but interval %q is non-positive; defaulting to %s", c.UsageTelemetry.Interval, defaultUsageTelemetryInterval)
+		c.UsageTelemetry.Interval = defaultUsageTelemetryInterval
 	}
 	if strings.TrimSpace(c.UsageTelemetry.InstallID) == "" {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but no install id found; disabling usage telemetry (set CRUISEKUBE_USAGETELEMETRY_INSTALLID to enable)")
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but no install id found; disabling usage telemetry (set CRUISEKUBE_USAGETELEMETRY_INSTALLID to enable)")
 		c.UsageTelemetry.Enabled = false
 		return nil
 	}
 	if len(c.UsageTelemetry.ProviderConfig) == 0 {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but providerConfig is empty; disabling usage telemetry (set usageTelemetry.providerConfig.host to enable)")
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but providerConfig is empty; disabling usage telemetry (set usageTelemetry.providerConfig.host to enable)")
 		c.UsageTelemetry.Enabled = false
 		return nil
 	}
 	if c.EffectiveUsageTelemetryProviderAPIKey() == "" {
-		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but no provider API key found; disabling usage telemetry (set usageTelemetry.providerApiKey / CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY, providerConfig.api_key, or bake USAGETELEMETRY_PROVIDER_API_KEY at image build)")
+		logging.Warnf(ctx, "usageTelemetry.enabled=true but no provider API key found; disabling usage telemetry (set usageTelemetry.providerApiKey / CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY, providerConfig.api_key, or bake USAGETELEMETRY_PROVIDER_API_KEY at image build)")
 		c.UsageTelemetry.Enabled = false
 		return nil
 	}

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/truefoundry/cruisekube/pkg/buildmetadata"
+	"github.com/truefoundry/cruisekube/pkg/logging"
 )
 
 // LoadWithViperInstance loads configuration using a provided Viper instance (for flag binding).
@@ -191,23 +192,34 @@ func (c *Config) validateUsageTelemetryForController() error {
 	}
 	interval := strings.TrimSpace(c.UsageTelemetry.Interval)
 	if interval == "" {
-		return fmt.Errorf("usageTelemetry.interval is required when usageTelemetry.enabled is true")
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval is empty; defaulting to 30m")
+		c.UsageTelemetry.Interval = "30m"
+		interval = "30m"
 	}
 	d, err := time.ParseDuration(interval)
 	if err != nil {
-		return fmt.Errorf("usageTelemetry.interval: %w", err)
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval %q is invalid (%v); defaulting to 30m", c.UsageTelemetry.Interval, err)
+		c.UsageTelemetry.Interval = "30m"
+		d = 30 * time.Minute
 	}
 	if d <= 0 {
-		return fmt.Errorf("usageTelemetry.interval must be positive, got %q", c.UsageTelemetry.Interval)
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but interval %q is non-positive; defaulting to 30m", c.UsageTelemetry.Interval)
+		c.UsageTelemetry.Interval = "30m"
 	}
 	if strings.TrimSpace(c.UsageTelemetry.InstallID) == "" {
-		return fmt.Errorf("usageTelemetry.installID is required when usageTelemetry.enabled is true (set CRUISEKUBE_USAGETELEMETRY_INSTALLID)")
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but no install id found; disabling usage telemetry (set CRUISEKUBE_USAGETELEMETRY_INSTALLID to enable)")
+		c.UsageTelemetry.Enabled = false
+		return nil
 	}
 	if len(c.UsageTelemetry.ProviderConfig) == 0 {
-		return fmt.Errorf("usageTelemetry.providerConfig must be non-empty when usageTelemetry.enabled is true")
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but providerConfig is empty; disabling usage telemetry (set usageTelemetry.providerConfig.host to enable)")
+		c.UsageTelemetry.Enabled = false
+		return nil
 	}
 	if c.EffectiveUsageTelemetryProviderAPIKey() == "" {
-		return fmt.Errorf("usageTelemetry provider API key is required when usageTelemetry.enabled is true (set usageTelemetry.providerApiKey / CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY, providerConfig.api_key in YAML, or bake USAGETELEMETRY_PROVIDER_API_KEY at image build)")
+		logging.Warnf(context.Background(), "usageTelemetry.enabled=true but no provider API key found; disabling usage telemetry (set usageTelemetry.providerApiKey / CRUISEKUBE_USAGETELEMETRY_PROVIDERAPIKEY, providerConfig.api_key, or bake USAGETELEMETRY_PROVIDER_API_KEY at image build)")
+		c.UsageTelemetry.Enabled = false
+		return nil
 	}
 	return nil
 }

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ func TestValidateRejectsInvalidExecutionMode(t *testing.T) {
 	cfg := validControllerConfig()
 	cfg.ExecutionMode = ExecutionMode("invalid")
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for invalid execution mode")
 	}
@@ -24,7 +25,7 @@ func TestValidateRejectsInvalidControllerMode(t *testing.T) {
 	cfg := validControllerConfig()
 	cfg.ControllerMode = ControllerMode("invalid")
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for invalid controller mode")
 	}
@@ -37,7 +38,7 @@ func TestValidateRejectsMissingTaskConfigs(t *testing.T) {
 	cfg := validControllerConfig()
 	delete(cfg.Controller.Tasks, CreateStatsKey)
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for missing task config")
 	}
@@ -53,7 +54,7 @@ func TestValidateRejectsMissingInClusterPrometheusURL(t *testing.T) {
 	cfg := validControllerConfig()
 	cfg.Dependencies.InCluster.PrometheusURL = ""
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for missing prometheus URL")
 	}
@@ -67,7 +68,7 @@ func TestValidateRejectsMissingLocalPrometheusURL(t *testing.T) {
 	cfg.ControllerMode = ClusterModeLocal
 	cfg.Dependencies.Local.PrometheusURL = ""
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for missing local prometheus URL")
 	}
@@ -85,7 +86,7 @@ func TestValidateAllowsUsageTelemetryWithoutProviderAPIKey(t *testing.T) {
 		InstallID:      "install",
 		ProviderConfig: map[string]interface{}{"host": "https://us.i.posthog.com"},
 	}
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err != nil {
 		t.Fatalf("expected validation to pass even when provider API key is missing, got %v", err)
 	}
@@ -105,7 +106,7 @@ func TestValidateAllowsUsageTelemetryAfterHydrateWithProviderApiKeyField(t *test
 	if err := hydrateUsageTelemetryProviderConfig(v, cfg); err != nil {
 		t.Fatal(err)
 	}
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Validate(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -123,7 +124,7 @@ func TestValidateRejectsUsageTelemetryNonPositiveInterval(t *testing.T) {
 				ProviderAPIKey: "x",
 				ProviderConfig: map[string]interface{}{"host": "https://us.i.posthog.com"},
 			}
-			err := cfg.Validate()
+			err := cfg.Validate(context.Background())
 			if err != nil {
 				t.Fatalf("expected validation to pass (interval should default), got %v", err)
 			}
@@ -139,7 +140,7 @@ func TestValidateRejectsMissingWebhookFields(t *testing.T) {
 	cfg.Webhook.Port = ""
 	cfg.Webhook.CertsDir = ""
 
-	err := cfg.Validate()
+	err := cfg.Validate(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for missing webhook fields")
 	}

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -76,7 +76,7 @@ func TestValidateRejectsMissingLocalPrometheusURL(t *testing.T) {
 	}
 }
 
-func TestValidateRequiresUsageTelemetryProviderAPIKey(t *testing.T) {
+func TestValidateAllowsUsageTelemetryWithoutProviderAPIKey(t *testing.T) {
 	t.Parallel()
 	cfg := validControllerConfig()
 	cfg.UsageTelemetry = UsageTelemetryConfig{
@@ -86,11 +86,8 @@ func TestValidateRequiresUsageTelemetryProviderAPIKey(t *testing.T) {
 		ProviderConfig: map[string]interface{}{"host": "https://us.i.posthog.com"},
 	}
 	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected validation error when api_key is missing")
-	}
-	if !strings.Contains(err.Error(), "provider API key") {
-		t.Fatalf("expected provider API key error, got %v", err)
+	if err != nil {
+		t.Fatalf("expected validation to pass even when provider API key is missing, got %v", err)
 	}
 }
 
@@ -123,14 +120,15 @@ func TestValidateRejectsUsageTelemetryNonPositiveInterval(t *testing.T) {
 				Enabled:        true,
 				Interval:       interval,
 				InstallID:      "abc",
-				ProviderConfig: map[string]interface{}{"api_key": "x"},
+				ProviderAPIKey: "x",
+				ProviderConfig: map[string]interface{}{"host": "https://us.i.posthog.com"},
 			}
 			err := cfg.Validate()
-			if err == nil {
-				t.Fatal("expected validation error")
+			if err != nil {
+				t.Fatalf("expected validation to pass (interval should default), got %v", err)
 			}
-			if !strings.Contains(err.Error(), "usageTelemetry.interval must be positive") {
-				t.Fatalf("expected positive interval error, got %v", err)
+			if cfg.UsageTelemetry.Interval != "30m" {
+				t.Fatalf("expected interval to default to 30m, got %q", cfg.UsageTelemetry.Interval)
 			}
 		})
 	}

--- a/test/e2e/manifest/global/values-cruisekube.yaml
+++ b/test/e2e/manifest/global/values-cruisekube.yaml
@@ -24,7 +24,7 @@ cruisekubeController:
   image:
     repository: cruisekube
     tag: latest
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Never
   env:
     CRUISEKUBE_DEPENDENCIES_LOCAL_INSECURESKIPTLSVERIFY: "false"
     CRUISEKUBE_DEPENDENCIES_INCLUSTER_PROMETHEUSURL: "http://localhost:9090"

--- a/test/e2e/manifest/global/values-cruisekube.yaml
+++ b/test/e2e/manifest/global/values-cruisekube.yaml
@@ -16,14 +16,14 @@ cruisekubeController:
         repository: bitnami/kubectl
         tag: "latest"
   usageTelemetry:
-    enabled: true
+    enabled: false
     interval: 30m
     providerConfig: {}
   serviceMonitor:
     enabled: false
   image:
-    repository: tfy.jfrog.io/tfy-images/cruisekube
-    tag: f50dec7c5a33cfc4cbd1459e4dbe1d8f22abf9b0
+    repository: cruisekube
+    tag: latest
     imagePullPolicy: IfNotPresent
   env:
     CRUISEKUBE_DEPENDENCIES_LOCAL_INSECURESKIPTLSVERIFY: "false"

--- a/test/e2e/manifest/global/values-cruisekube.yaml
+++ b/test/e2e/manifest/global/values-cruisekube.yaml
@@ -16,15 +16,15 @@ cruisekubeController:
         repository: bitnami/kubectl
         tag: "latest"
   usageTelemetry:
-    enabled: false
+    enabled: true
     interval: 30m
     providerConfig: {}
   serviceMonitor:
     enabled: false
   image:
-    repository: cruisekube
-    tag: latest
-    imagePullPolicy: Never
+    repository: tfy.jfrog.io/tfy-images/cruisekube
+    tag: 7becf2b474a5eb847a474b0c9c0fa773c73cbe50
+    imagePullPolicy: IfNotPresent
   env:
     CRUISEKUBE_DEPENDENCIES_LOCAL_INSECURESKIPTLSVERIFY: "false"
     CRUISEKUBE_DEPENDENCIES_INCLUSTER_PROMETHEUSURL: "http://localhost:9090"

--- a/test/e2e/manifest/global/values-cruisekube.yaml
+++ b/test/e2e/manifest/global/values-cruisekube.yaml
@@ -23,7 +23,7 @@ cruisekubeController:
     enabled: false
   image:
     repository: tfy.jfrog.io/tfy-images/cruisekube
-    tag: 7becf2b474a5eb847a474b0c9c0fa773c73cbe50
+    tag: f50dec7c5a33cfc4cbd1459e4dbe1d8f22abf9b0
     imagePullPolicy: IfNotPresent
   env:
     CRUISEKUBE_DEPENDENCIES_LOCAL_INSECURESKIPTLSVERIFY: "false"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/build pipelines (GitHub Actions image build/push logic) and alters runtime config validation behavior by auto-defaulting/disabling usage telemetry instead of failing startup.
> 
> **Overview**
> **CI/CD workflows are inlined** for `cruisekube` image builds on `main` and on releases, replacing the reusable `github-workflows-public` build workflow to avoid multiline `build-args` being JSON-escaped; this also adds explicit Artifactory login/tag preparation and registry cache configuration.
> 
> **Usage telemetry config validation is relaxed**: `Config.Validate` now takes a `context.Context` and logs warnings while defaulting the interval to `30m` or disabling usage telemetry when required fields (install ID, provider config, provider API key) are missing/invalid, rather than erroring.
> 
> **Build artifacts and chart UX tweaks**: Docker builds now accept `USAGETELEMETRY_PROVIDER_API_KEY` as a build arg and strip binaries via `-s -w`, and Helm `NOTES.txt` block endings are fixed to render correctly. Tests are updated to match the new validation semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8a8d9e9335a0ae6e5b716257b659982a8b94e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation for usage telemetry settings; now logs warnings and applies sensible defaults instead of failing validation when telemetry interval is invalid or missing—defaults to 30 minutes.
  * Telemetry now gracefully handles missing provider configuration by disabling the feature with warnings rather than blocking startup.

* **Chores**
  * Enhanced CI/CD workflows and Helm template documentation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->