### PR TITLE
Group Sentry errors by call stack for better clustering

### DIFF
--- a/pkg/logging/sentry.go
+++ b/pkg/logging/sentry.go
@@ -30,6 +30,9 @@ func (s *sentryReporter) CaptureErrors(errs []error, msg string, tags map[string
 		event := sentry.NewEvent()
 		event.Level = sentry.LevelError
 		event.Message = msg
+		// Group by call stack so errors from the same code location are clustered
+		// together even when the message contains dynamic values (workload names, etc.).
+		event.Fingerprint = []string{"{{ stack }}"}
 
 		event.Exception = []sentry.Exception{
 			{
@@ -47,6 +50,7 @@ func (s *sentryReporter) CaptureMessage(msg string, tags map[string]string) {
 		for k, v := range tags {
 			scope.SetTag(k, v)
 		}
+		scope.SetFingerprint([]string{"{{ stack }}"})
 		sentry.CaptureMessage(msg)
 	})
 }


### PR DESCRIPTION
## Description
This change improves error grouping in Sentry by setting a fingerprint based on the call stack for both error and message events. This ensures that errors originating from the same code location are clustered together in Sentry, even when the error message contains dynamic values (such as workload names, timestamps, etc.).

Previously, errors with identical code origins but different dynamic message content would be grouped as separate issues in Sentry, making it harder to identify and track recurring problems.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This change affects Sentry event fingerprinting behavior. The implementation uses Sentry's standard `{{ stack }}` fingerprint template, which is a built-in feature. Verification can be done by:
- Triggering errors from the same code location with different message content
- Confirming they are grouped under a single Sentry issue rather than multiple issues

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made

https://claude.ai/code/session_015LMWC2kgzWTqt2XSKYPeBu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes Sentry event fingerprinting/grouping behavior and does not affect application control flow or data handling.
> 
> **Overview**
> Improves Sentry issue clustering by setting the fingerprint to `{{ stack }}` for both error events created in `CaptureErrors` and message events sent via `CaptureMessage`, so events from the same call site group together even when messages include dynamic values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfb78aafc0dc27d67d7ead67f7529c7e8ddc386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Sentry error monitoring with call stack-based event grouping. Error events and captured messages are now organized by their call stacks, improving how similar issues are clustered together throughout the application. This provides clearer visibility into recurring problems and streamlines error tracking and investigation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truefoundry/CruiseKube/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->