### PR TITLE
fix: properly return database errors in HasCluster and HasWorkloadFor…

### DIFF
--- a/pkg/adapters/database/database.go
+++ b/pkg/adapters/database/database.go
@@ -155,14 +155,13 @@ func (s *GormDB) HasRecentStat(clusterID, workloadID string, withinMinutes int) 
 
 func (s *GormDB) HasCluster(clusterID string) (bool, error) {
 	count, err := s.GetStatCountForCluster(clusterID)
-	return err == nil && count > 0, nil
+	return count > 0, err
 }
 
 func (s *GormDB) HasWorkloadForCluster(clusterID, workloadID string) (bool, error) {
 	count, err := s.getWorkloadCountForCluster(clusterID, workloadID)
-	return err == nil && count > 0, nil
+	return count > 0, err
 }
-
 func (s *GormDB) GetStatsForCluster(clusterID string) ([]types.WorkloadStat, error) {
 	var rows []Workload
 	err := s.db.Where(&Workload{ClusterID: clusterID}).


### PR DESCRIPTION
## Description
Fixed error handling in `HasCluster` and `HasWorkloadForCluster` functions that were silently discarding database errors.

## Changes
- `HasCluster` now properly returns database errors instead of always returning `nil`
- `HasWorkloadForCluster` now properly returns database errors instead of always returning `nil`
- Changed from `return err == nil && count > 0, nil` to `return count > 0, err`

## Issue
Fixes #113

## Testing
- Code compiles without errors
- Changes are minimal and focused on error handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling fix with no API change; behavior improves for callers that already check errors.
> 
> **Overview**
> **`HasCluster`** and **`HasWorkloadForCluster`** no longer swallow database errors from their count queries. Both now return `count > 0, err` instead of `err == nil && count > 0, nil`, so callers such as **`ClusterStatsExists`** and **`UpdateWorkloadOverrides`** can distinguish query failures from “not found” instead of treating failures as absent clusters or workloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf33543cf3acb1cb4c4cda0a025cd2b4bde5a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in cluster operations to properly surface query errors instead of masking them, improving visibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->