### PR TITLE
feat: update config for standalone prometheus

### DIFF
--- a/docs/install/gs-prerequisites.md
+++ b/docs/install/gs-prerequisites.md
@@ -87,6 +87,14 @@ The dedicated instance should **scrape** kube-state-metrics, node-exporter, and 
 1. Save the following as `standalone-prometheus-values.yaml`. It disables bundled node-exporter and kube-state-metrics (so you do not conflict with existing DaemonSets) and discovers existing cluster targets via `kubernetes_sd_configs`.
 
 ```yaml
+server:
+  global:
+    scrape_interval: 15s
+
+scrapeConfigs:
+  kubernetes-nodes-cadvisor:
+    enabled: false
+
 serverFiles:
   prometheus.yml:
     scrape_configs:

--- a/docs/install/gs-prerequisites.md
+++ b/docs/install/gs-prerequisites.md
@@ -118,11 +118,15 @@ serverFiles:
 
       - job_name: kubelet
         scheme: https
+        metrics_path: /metrics/cadvisor
         kubernetes_sd_configs:
           - role: node
         tls_config:
           insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
 
 prometheus-node-exporter:
   enabled: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to an install example; no runtime or application code is modified.
> 
> **Overview**
> Updates the **Scenario 3 — Dedicated standalone Prometheus** example in `docs/install/gs-prerequisites.md` so the official Prometheus chart values align with what CruiseKube expects from kubelet/cAdvisor scrapes.
> 
> The sample now sets a **15s global scrape interval**, disables the chart’s bundled **`kubernetes-nodes-cadvisor`** scrape (avoiding duplicate cAdvisor discovery when kubelet is configured manually), and extends the **kubelet** job with **`/metrics/cadvisor`**, plus relabeling to populate the **`node`** label from the Kubernetes node name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3c0f334ce41bb2e963373508c3aba7d2d18047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the standalone Prometheus installation example to use a 15-second scrape interval.
  * Clarified the example configuration by disabling the Kubernetes nodes cAdvisor scrape setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->