### PR TITLE
docs; update standalone prom values

### DIFF
--- a/docs/install/gs-installation.md
+++ b/docs/install/gs-installation.md
@@ -25,6 +25,15 @@ helm install cruisekube oci://tfy.jfrog.io/tfy-helm/cruisekube \
   --set cruisekubeController.env.CRUISEKUBE_DEPENDENCIES_INCLUSTER_PROMETHEUSURL="http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090" 
 ```
 
+!!! note "Set and verify the Prometheus URL"
+    Replace the example `CRUISEKUBE_DEPENDENCIES_INCLUSTER_PROMETHEUSURL` with the **in-cluster Service URL** of the Prometheus instance CruiseKube should query (not `localhost`). Confirm the Service exists and is reachable from the controller namespace before you install:
+
+    ```bash
+    kubectl get svc -A | grep -i prometheus
+    ```
+
+    This URL directly affects whether CruiseKube can fetch metrics — wrong or unreachable endpoints lead to empty or incomplete recommendations. See [Prometheus prerequisites](gs-prerequisites.md#prometheus) to pick the right instance, and [Troubleshooting — Prometheus metrics](../documentation/operate/operate-troubleshooting.md) if metrics look missing after install.
+
 > Customize any installation with a [`values.yaml`](https://github.com/truefoundry/CruiseKube/blob/main/charts/cruisekube/values.yaml) file.
 
 <br />

--- a/docs/install/gs-prerequisites.md
+++ b/docs/install/gs-prerequisites.md
@@ -87,15 +87,15 @@ The dedicated instance should **scrape** kube-state-metrics, node-exporter, and 
 1. Save the following as `standalone-prometheus-values.yaml`. It disables bundled node-exporter and kube-state-metrics (so you do not conflict with existing DaemonSets) and discovers existing cluster targets via `kubernetes_sd_configs`.
 
 !!! warning "Customize the relabel regex before you install"
-    The `kube-state-metrics` and `node-exporter` jobs filter discovered endpoints with a regex on **`{namespace}_{service_name}`** (namespace and Service name joined by `_`). The examples below assume kube-prometheus-stack in the **`monitoring`** namespace (`monitoring_prometheus-kube-state-metrics`, `monitoring_prometheus-prometheus-node-exporter`).
+    The `kube-state-metrics` and `node-exporter` jobs filter discovered endpoints with a regex on the Kubernetes **Service name** (`__meta_kubernetes_service_name` only — not namespace). The examples below use common kube-prometheus-stack names: `prometheus-kube-state-metrics` and `prometheus-prometheus-node-exporter`.
 
-    **Before applying**, list your exporters and set each regex to match your cluster:
+    **Before applying**, list your exporters and set each `regex` to the **Service name** in your cluster:
 
     ```bash
     kubectl get svc -A | grep -E 'kube-state-metrics|node-exporter'
     ```
 
-    For each target, use `<namespace>_<service-name>` as the `regex` value. If the regex does not match, Prometheus will scrape nothing and CruiseKube will have no metrics.
+    Use the **NAME** column value as the `regex`. If it does not match, Prometheus will scrape nothing and CruiseKube will have no metrics.
 
 ```yaml
 server:
@@ -121,7 +121,7 @@ serverFiles:
         relabel_configs:
           - source_labels:
               - __meta_kubernetes_service_name
-            regex: monitoring_prometheus-kube-state-metrics
+            regex: prometheus-kube-state-metrics
             action: keep
 
       - job_name: node-exporter

--- a/docs/install/gs-prerequisites.md
+++ b/docs/install/gs-prerequisites.md
@@ -86,10 +86,27 @@ The dedicated instance should **scrape** kube-state-metrics, node-exporter, and 
 
 1. Save the following as `standalone-prometheus-values.yaml`. It disables bundled node-exporter and kube-state-metrics (so you do not conflict with existing DaemonSets) and discovers existing cluster targets via `kubernetes_sd_configs`.
 
+!!! warning "Customize the relabel regex before you install"
+    The `kube-state-metrics` and `node-exporter` jobs filter discovered endpoints with a regex on **`{namespace}_{service_name}`** (namespace and Service name joined by `_`). The examples below assume kube-prometheus-stack in the **`monitoring`** namespace (`monitoring_prometheus-kube-state-metrics`, `monitoring_prometheus-prometheus-node-exporter`).
+
+    **Before applying**, list your exporters and set each regex to match your cluster:
+
+    ```bash
+    kubectl get svc -A | grep -E 'kube-state-metrics|node-exporter'
+    ```
+
+    For each target, use `<namespace>_<service-name>` as the `regex` value. If the regex does not match, Prometheus will scrape nothing and CruiseKube will have no metrics.
+
 ```yaml
 server:
   global:
     scrape_interval: 15s
+  retention: "30d"
+  retentionSize: "50GB"
+  persistentVolume:
+    enabled: true
+    size: 50Gi
+    # storageClass: ""  # omit to use the cluster default StorageClass
 
 scrapeConfigs:
   kubernetes-nodes-cadvisor:
@@ -104,7 +121,7 @@ serverFiles:
         relabel_configs:
           - source_labels:
               - __meta_kubernetes_service_name
-            regex: prometheus-kube-state-metrics
+            regex: monitoring_prometheus-kube-state-metrics
             action: keep
 
       - job_name: node-exporter


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only changes to install and prerequisite guides; no runtime or chart behavior changes.
> 
> **Overview**
> Documentation updates for Prometheus setup during CruiseKube install.
> 
> **Installation** adds a note on setting `CRUISEKUBE_DEPENDENCIES_INCLUSTER_PROMETHEUSURL` to an in-cluster Service URL (not `localhost`), with `kubectl get svc` to verify reachability and pointers to prerequisites and troubleshooting when metrics are missing.
> 
> **Standalone Prometheus prerequisites** add a warning to tune `kube-state-metrics` and `node-exporter` scrape relabel `regex` values to match actual Kubernetes **Service names** before install, plus a `kubectl get svc` example. The sample `standalone-prometheus-values.yaml` now includes **30d retention**, **50GB retention size**, and **50Gi persistent volume** settings under `server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a658b05e188f5d448d94ef9a8ee8133e36117b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the standalone Prometheus installation guide with clearer setup guidance.
  * Added a warning to help users adjust discovery matching to fit their namespace and service naming pattern.
  * Expanded the example configuration with retention and persistent storage settings.
  * Revised the sample exporter matching pattern to align with the documented naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->