### PR TITLE
ci: migrate build-n-publish.yml to shared reusable build.yml (INFRA-1109)

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -9,136 +9,52 @@ permissions:
   id-token: write
   contents: read
 
-
 jobs:
-  # Inlined (not github-workflows-public build.yml): that workflow passes
-  # build-args: ${{ toJSON(inputs.image_build_args) }}, which JSON-escapes newlines.
-  # docker/build-push-action expects newline-delimited KEY=VAL lines; a single JSON
-  # string merges lines into the first arg (API key value gets "\nVERSION=…", VERSION stays default dev).
+  # Build and push the cruisekube operator image via the shared reusable workflow.
   build-operator:
     name: Build and Push Docker Images
-    runs-on: ubuntu-latest
+    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
     permissions:
       id-token: write
       contents: read
-    env:
-      IMAGE_TAG: ${{ github.sha }}
-      IMAGE_ARTIFACT_NAME: "cruisekube"
-      DOCKERFILE_PATH: "Dockerfile"
-      IMAGE_CONTEXT: "."
-      ARTIFACTORY_REGISTRY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
-      ARTIFACTORY_REPOSITORY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
-      PLATFORMS: "linux/amd64"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    with:
+      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      image_artifact_name: cruisekube
+      image_tag: ${{ github.sha }}
+      image_context: .
+      dockerfile_path: Dockerfile
+      platforms: linux/amd64
+      image_build_args: |
+        VERSION=${{ github.sha }}
+    secrets:
+      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      image_build_secrets: |
+        USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
 
-      - name: Validate registry configuration
-        run: |
-          if [ -z "$ARTIFACTORY_REGISTRY_URL" ] || [ -z "$ARTIFACTORY_REPOSITORY_URL" ]; then
-            echo "Error: Artifactory registry or repository URL is not set"
-            exit 1
-          fi
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to JFrog Artifactory
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.ARTIFACTORY_REGISTRY_URL }}
-          username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-          password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-
-      - name: Prepare image tags
-        id: prepare_tags
-        run: |
-          FULL_IMAGE_NAME="${ARTIFACTORY_REPOSITORY_URL}/${IMAGE_ARTIFACT_NAME}"
-          IMAGE_WITH_TAG="${FULL_IMAGE_NAME}:${IMAGE_TAG}"
-          echo "image=${IMAGE_WITH_TAG}" >> $GITHUB_OUTPUT
-          echo "image_name=${FULL_IMAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "Image: ${IMAGE_WITH_TAG}"
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ env.IMAGE_CONTEXT }}
-          file: ${{ env.DOCKERFILE_PATH }}
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          tags: ${{ steps.prepare_tags.outputs.image }}
-          cache-from: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache,mode=max,image-manifest=true,compression=zstd
-          build-args: |
-            USAGETELEMETRY_PROVIDER_API_KEY=${{ secrets.POSTHOG_API_KEY }}
-            VERSION=${{ github.sha }}
-
-  # Build and push cruisekube-frontend image
+  # Build and push the cruisekube-frontend image via the shared reusable workflow.
+  # The frontend source lives in a git submodule, so submodule checkout + token are required.
   build-cruisekube-frontend:
     name: Build and Push cruisekube-frontend Docker Images
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: ${{ github.sha }}
-      IMAGE_ARTIFACT_NAME: "cruisekube-frontend"
-      DOCKERFILE_PATH: "cruiseKube-frontend/Dockerfile"
-      IMAGE_CONTEXT: "cruiseKube-frontend"
-      ARTIFACTORY_REGISTRY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
-      ARTIFACTORY_REPOSITORY_URL: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
-      PLATFORMS: 'linux/amd64'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: "0"
-          submodules: "recursive"
-          token: ${{ secrets.CRUISE_KUBE_CI_SECRET }}
-
-      - name: Validate registry configuration
-        run: |
-          if [ -z "$ARTIFACTORY_REGISTRY_URL" ] || [ -z "$ARTIFACTORY_REPOSITORY_URL" ]; then
-            echo "Error: Artifactory registry or repository URL is not set"
-            exit 1
-          fi
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to JFrog Artifactory
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.ARTIFACTORY_REGISTRY_URL }}
-          username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-          password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
-
-      - name: Prepare image tags
-        id: prepare_tags
-        run: |
-          FULL_IMAGE_NAME="${ARTIFACTORY_REPOSITORY_URL}/${IMAGE_ARTIFACT_NAME}"
-          IMAGE_WITH_TAG="${FULL_IMAGE_NAME}:${IMAGE_TAG}"
-          echo "image=${IMAGE_WITH_TAG}" >> $GITHUB_OUTPUT
-          echo "image_name=${FULL_IMAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "Image: ${IMAGE_WITH_TAG}"
-
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ env.IMAGE_CONTEXT }}
-          file: ${{ env.DOCKERFILE_PATH }}
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          tags: ${{ steps.prepare_tags.outputs.image }}
-          cache-from: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ steps.prepare_tags.outputs.image_name }}:buildcache,mode=max
-
-      - name: Output image digest
-        run: |
-          echo "Image digest for ${{ steps.prepare_tags.outputs.image }} has been pushed successfully"
+    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      image_artifact_name: cruisekube-frontend
+      image_tag: ${{ github.sha }}
+      image_context: cruiseKube-frontend
+      dockerfile_path: cruiseKube-frontend/Dockerfile
+      platforms: linux/amd64
+      checkout_submodules: recursive
+      checkout_fetch_depth: 0
+    secrets:
+      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      checkout_token: ${{ secrets.CRUISE_KUBE_CI_SECRET }}
 
   # We are updating the sha in the helm chart values.yaml file on the helm-main branch
   update-helm-chart:


### PR DESCRIPTION
## Summary
Replaces the inlined `build-operator` and `build-cruisekube-frontend` jobs in `build-n-publish.yml` with calls to the shared reusable `truefoundry/github-workflows-public` `build.yml@main`.

- `VERSION` is passed via `image_build_args`; `POSTHOG_API_KEY` via the new `image_build_secrets` secret (the caller `with:` block cannot reference the `secrets` context).
- The `cruiseKube-frontend` build context lives in a git submodule, so it passes `checkout_submodules: recursive` and `checkout_token`.
- `update-helm-chart` remains inlined.

> Depends on truefoundry/github-workflows-public#22 landing on `main` (this workflow references `build.yml@main`).

## Test plan
- [ ] Merge the public `build.yml` PR first.
- [ ] Push to `main` triggers the workflow; operator + frontend images build and push to JFrog with correct tags.
- [ ] Verify operator image has non-default `VERSION` and the telemetry API key build-arg applied.
- [ ] Verify `update-helm-chart` still updates values.yaml on `helm-main`.

Linear: INFRA-1109

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image build and publish process to use a shared reusable workflow for both backend and frontend images.
  * Streamlined how container images are built and tagged, while keeping the published artifacts the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->