### PR TITLE
fix: mark psi as optional, reduce minimum k8s version requirements, and upadte the script"

### DIFF
--- a/docs/documentation/operate/preflight.md
+++ b/docs/documentation/operate/preflight.md
@@ -55,12 +55,12 @@ If Prometheus cannot be reached, the response reports the exact **target** it tr
 
 | Component | Minimum | Why |
 |-----------|---------|-----|
-| Kubernetes **server** (control plane) | **v1.34.0** | Required for pod in-place resource updates and PSI metrics |
-| **Node** kubelet (checked per node) | **v1.34.0** | Same features run on the nodes; kubelets must also be 1.34+ |
+| Kubernetes **server** (control plane) | **v1.33.0** | Required for pod in-place resource updates (beta / on by default from 1.33) |
+| **Node** kubelet (checked per node) | **v1.33.0** | Same feature runs on the nodes; kubelets must also be 1.33+ |
 | Prometheus | **2.30.0** | Query features CruiseKube relies on |
 
 !!! info "Why both Kubernetes and node versions?"
-    The **Kubernetes version** is the control-plane / API-server version (one per cluster). The **node version** is the kubelet version on each individual node. CruiseKube's core features — **pod in-place resource updates** (in-place vertical scaling) and **PSI (pressure stall information) metrics** — are executed by the kubelet on each node. Kubernetes' version-skew policy lets kubelets lag the API server by up to three minor versions, so a cluster can have a 1.34 control plane but older nodes. Checking only the server version would let such a cluster pass while the features silently do not work on the older nodes — so preflight requires **both** the server and every node's kubelet to be ≥ 1.34.
+    The **Kubernetes version** is the control-plane / API-server version (one per cluster). The **node version** is the kubelet version on each individual node. CruiseKube's core feature — **pod in-place resource updates** (in-place vertical scaling) — is executed by the kubelet on each node. Kubernetes' version-skew policy lets kubelets lag the API server by up to three minor versions, so a cluster can have a 1.33 control plane but older nodes. Checking only the server version would let such a cluster pass while the feature silently does not work on the older nodes — so preflight requires **both** the server and every node's kubelet to be ≥ 1.33. (**PSI (pressure stall information) metrics** are supported but optional — their absence does not block the dashboard.)
 
 The versions step also reports the running **CruiseKube version** (informational — it does not affect the verdict) so it appears in the report.
 
@@ -73,11 +73,12 @@ CruiseKube verifies that the Prometheus metrics it relies on actually exist, gro
 | `kube-state-metrics` | `job="kube-state-metrics"` | `kube_pod_info`, `kube_pod_status_phase`, `kube_node_status_allocatable`, `kube_pod_container_status_restarts_total`, `kube_node_labels` |
 | `cadvisor-kubelet` | `job=~"kubelet\|kubernetes-nodes-cadvisor"` | `container_cpu_usage_seconds_total`, `container_memory_working_set_bytes` |
 | `node-exporter` | `job="node-exporter"` | `node_load1`, `node_cpu_seconds_total` |
-| `psi` | (kubelet / node-exporter) | `container_pressure_cpu_waiting_seconds_total`, `node_pressure_cpu_waiting_seconds_total`, … |
+| `psi` (optional) | (kubelet / node-exporter) | `container_pressure_cpu_waiting_seconds_total`, `node_pressure_cpu_waiting_seconds_total`, … |
 | `karpenter` | — | `karpenter_nodeclaims_disrupted_total` |
 
-A few metrics are **probed but not required** because they are legitimately empty on a healthy cluster and must not block the dashboard:
+Some metrics are **probed but not required** because they are legitimately absent on a healthy cluster and must not block the dashboard:
 
+- The whole **`psi`** group — PSI (pressure stall information) is kernel/PSI-gated and not enabled on every cluster. PSI metrics are reported (present or not, with labels) but never block the dashboard.
 - `kube_node_spec_taint` — no series when no nodes are tainted.
 - `kube_pod_container_status_last_terminated_reason` — no series until a container has terminated (e.g. OOM).
 - `karpenter_nodeclaims_disrupted_total` — Karpenter-only; empty until a disruption occurs.
@@ -116,7 +117,7 @@ Failed **optional** checks are reported but do not affect `healthy`.
     { "step": "prometheus_connectivity", "item": "prometheus",
       "message": "failed to reach Prometheus at http://prometheus:9090: dial tcp: i/o timeout" },
     { "step": "versions", "item": "kubernetes",
-      "message": "kubernetes server version v1.30.0 is below minimum 1.34.0" }
+      "message": "kubernetes server version v1.30.0 is below minimum 1.33.0" }
   ],
   "prometheus_connectivity": {
     "connected": true, "healthy": true,
@@ -127,8 +128,8 @@ Failed **optional** checks are reported but do not affect `healthy`.
   "versions": {
     "passed": true,
     "cruisekube_version": "0.3.3",
-    "min_kube_version": "1.34.0",
-    "min_kubernetes_version": "1.34.0",
+    "min_kube_version": "1.33.0",
+    "min_kubernetes_version": "1.33.0",
     "min_prometheus_version": "2.30.0",
     "kubernetes": { "version": "v1.34.2", "meets_minimum": true },
     "nodes": [ { "name": "node-a", "kubelet_version": "v1.34.2", "meets_minimum": true } ],
@@ -176,4 +177,4 @@ If the preflight reports problems, see [Troubleshooting](operate-troubleshooting
 
 - **Prometheus not reachable** — check the reported `target` URL/host/port and that the configured `dependencies.*.prometheusURL` points at a reachable Prometheus.
 - **Metrics missing** — confirm kube-state-metrics, cAdvisor/kubelet, and node-exporter are being scraped by the Prometheus CruiseKube is pointed at.
-- **Version below minimum** — upgrade the affected node(s) or control plane to Kubernetes 1.34+.
+- **Version below minimum** — upgrade the affected node(s) or control plane to Kubernetes 1.33+.

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -84,11 +84,12 @@ var preflightMetricProbes = []metricProbe{
 	// node-exporter
 	{"node_load1", `job="node-exporter"`, "node-exporter", true},
 	{"node_cpu_seconds_total", `job="node-exporter"`, "node-exporter", true},
-	// PSI pressure metrics (Kubernetes 1.34+ requirement — see version checks).
-	{"container_pressure_cpu_waiting_seconds_total", `job=~"kubelet|kubernetes-nodes-cadvisor"`, "psi", true},
-	{"container_pressure_memory_waiting_seconds_total", `job=~"kubelet|kubernetes-nodes-cadvisor"`, "psi", true},
-	{"node_pressure_cpu_waiting_seconds_total", `job="node-exporter"`, "psi", true},
-	{"node_pressure_memory_waiting_seconds_total", `job="node-exporter"`, "psi", true},
+	// PSI pressure metrics — supported but OPTIONAL (kernel/PSI-gated and not
+	// enabled on every cluster), so probed and reported but non-blocking.
+	{"container_pressure_cpu_waiting_seconds_total", `job=~"kubelet|kubernetes-nodes-cadvisor"`, "psi", false},
+	{"container_pressure_memory_waiting_seconds_total", `job=~"kubelet|kubernetes-nodes-cadvisor"`, "psi", false},
+	{"node_pressure_cpu_waiting_seconds_total", `job="node-exporter"`, "psi", false},
+	{"node_pressure_memory_waiting_seconds_total", `job="node-exporter"`, "psi", false},
 	// Karpenter — only present on Karpenter clusters and legitimately zero-series
 	// when no disruptions have occurred, so probed but NOT required.
 	{"karpenter_nodeclaims_disrupted_total", "", "karpenter", false},

--- a/pkg/handlers/preflight_test.go
+++ b/pkg/handlers/preflight_test.go
@@ -319,6 +319,39 @@ func TestProbeMetricsMissingOne(t *testing.T) {
 	}
 }
 
+// TestProbeMetricsPSIOptional proves PSI metrics are optional: when only the PSI
+// metrics are absent, the report still passes and the psi group is non-required.
+func TestProbeMetricsPSIOptional(t *testing.T) {
+	client := &stubPromAPI{
+		queryFunc: func(q string) (model.Value, error) {
+			if strings.Contains(q, "_pressure_") { // PSI metrics absent
+				return model.Vector{}, nil
+			}
+			return countVector(1), nil
+		},
+		labelNamesFunc: func([]string) ([]string, error) { return []string{"job"}, nil },
+	}
+	report := probeMetrics(context.Background(), client, "15m", "")
+	if !report.Passed {
+		t.Fatal("report should pass when only optional PSI metrics are absent")
+	}
+	for _, g := range report.Groups {
+		if g.Name == "psi" {
+			if g.Required {
+				t.Fatal("psi group must be non-required")
+			}
+			if !g.Present {
+				t.Fatal("a group with no required checks stays present")
+			}
+			for _, ck := range g.Checks {
+				if ck.Required {
+					t.Fatalf("psi check %s must be optional", ck.Metric)
+				}
+			}
+		}
+	}
+}
+
 // TestProbeMetricsIncludesAbsentMetrics proves that ALL probed metrics are in the
 // report whether found or not, each with full info (present/series/labels/error),
 // and that labels serialize as [] (never null) even for absent metrics.

--- a/pkg/handlers/versions.go
+++ b/pkg/handlers/versions.go
@@ -15,18 +15,19 @@ import (
 )
 
 const (
-	// CruiseKube requires Kubernetes 1.34+ so the features it depends on are
-	// available: pod in-place resource updates (in-place vertical scaling) and PSI
-	// (pressure stall information) metrics. Both are kubelet/node-level features,
-	// so the per-node kubelet version and the server (control-plane) version share
-	// the same 1.34 floor — a 1.34 control plane with older kubelets would not
-	// actually support in-place resize or expose PSI on those nodes.
+	// CruiseKube requires Kubernetes 1.33+ so that pod in-place resource updates
+	// (in-place vertical scaling) are available — that feature is beta / enabled
+	// by default from 1.33. It is a kubelet/node-level feature, so both the
+	// per-node kubelet version and the server (control-plane) version must meet
+	// the 1.33 floor. PSI (pressure stall information) metrics are supported but
+	// optional: their absence does not block CruiseKube (see the "psi" metric
+	// group in preflight.go).
 
 	// defaultMinKubeVersion is the minimum per-node kubelet version.
-	defaultMinKubeVersion = "v1.34.0"
+	defaultMinKubeVersion = "v1.33.0"
 	// defaultMinKubernetesVersion is the minimum Kubernetes server (control-plane)
 	// version.
-	defaultMinKubernetesVersion = "v1.34.0"
+	defaultMinKubernetesVersion = "v1.33.0"
 	// defaultMinPrometheusVersion is the minimum Prometheus version CruiseKube
 	// requires.
 	defaultMinPrometheusVersion = "2.30.0"

--- a/scripts/cruisekube_diagnostics.py
+++ b/scripts/cruisekube_diagnostics.py
@@ -46,8 +46,8 @@ from typing import Callable, Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 # Policy — mirrors pkg/handlers (preflight). Keep in sync with the Go code.
 # ---------------------------------------------------------------------------
-MIN_KUBE_VERSION = "1.34.0"          # per-node kubelet
-MIN_KUBERNETES_VERSION = "1.34.0"    # control plane
+MIN_KUBE_VERSION = "1.33.0"          # per-node kubelet
+MIN_KUBERNETES_VERSION = "1.33.0"    # control plane
 MIN_PROMETHEUS_VERSION = "2.30.0"
 METRIC_LOOKBACK = "15m"
 MIN_SINCE_SECONDS = 3600             # "at least one hour" of logs
@@ -79,11 +79,11 @@ METRIC_PROBES: Tuple[MetricProbe, ...] = (
     # node-exporter
     MetricProbe("node_load1", 'job="node-exporter"', "node-exporter", True),
     MetricProbe("node_cpu_seconds_total", 'job="node-exporter"', "node-exporter", True),
-    # PSI pressure metrics (Kubernetes 1.34+)
-    MetricProbe("container_pressure_cpu_waiting_seconds_total", 'job=~"kubelet|kubernetes-nodes-cadvisor"', "psi", True),
-    MetricProbe("container_pressure_memory_waiting_seconds_total", 'job=~"kubelet|kubernetes-nodes-cadvisor"', "psi", True),
-    MetricProbe("node_pressure_cpu_waiting_seconds_total", 'job="node-exporter"', "psi", True),
-    MetricProbe("node_pressure_memory_waiting_seconds_total", 'job="node-exporter"', "psi", True),
+    # PSI pressure metrics — supported but OPTIONAL (non-blocking)
+    MetricProbe("container_pressure_cpu_waiting_seconds_total", 'job=~"kubelet|kubernetes-nodes-cadvisor"', "psi", False),
+    MetricProbe("container_pressure_memory_waiting_seconds_total", 'job=~"kubelet|kubernetes-nodes-cadvisor"', "psi", False),
+    MetricProbe("node_pressure_cpu_waiting_seconds_total", 'job="node-exporter"', "psi", False),
+    MetricProbe("node_pressure_memory_waiting_seconds_total", 'job="node-exporter"', "psi", False),
     # Karpenter (optional; empty until a disruption)
     MetricProbe("karpenter_nodeclaims_disrupted_total", "", "karpenter", False),
 )


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/cruisekube/tree/main/charts/cruisekube] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dashboard gating policy: clusters on 1.33 without PSI will now pass preflight where they previously failed, which may hide missing optional observability but does not weaken auth or data handling.
> 
> **Overview**
> Relaxes **preflight readiness** so more clusters can open the dashboard without failing on version or PSI gaps.
> 
> **Kubernetes minimum** drops from **1.34** to **1.33** for both the API server and every node kubelet, aligned with **pod in-place resource updates** (in-place vertical scaling) being the hard requirement from 1.33 onward. **PSI pressure metrics** are no longer part of that version story in the docs.
> 
> **PSI metric group** (`container_pressure_*`, `node_pressure_*`) is still probed and reported, but all four checks are **`Required: false`**, so missing PSI no longer fails `metrics.passed` or overall `healthy`. Documentation describes the `psi` group as optional and clarifies that PSI does not block the dashboard.
> 
> The same policy is mirrored in **`scripts/cruisekube_diagnostics.py`**, and **`TestProbeMetricsPSIOptional`** asserts that absent PSI alone still yields a passing metrics report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea10da6aa776786c60fa41bfcaec3849cc23c0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preflight checks now treat PSI pressure metrics as optional, so missing PSI metrics no longer cause health checks to fail.
  * Updated Kubernetes and kubelet minimum version checks to **1.33.0+**.
* **Documentation**
  * Revised preflight guidance, examples, and troubleshooting text to match the new version requirements and optional PSI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->